### PR TITLE
Add support for project-specific autowt.toml configuration files

### DIFF
--- a/.autowt.toml
+++ b/.autowt.toml
@@ -1,0 +1,1 @@
+init = "./setup.sh"

--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ autowt branch-name --init "npm install && npm run dev"
 
 The init script runs after changing to the worktree directory.
 
+### Project Configuration
+
+Create an `autowt.toml` or `.autowt.toml` file in your project root to set a default init script:
+
+```toml
+init = "npm install && npm run dev"
+```
+
+This eliminates the need to pass `--init` every time. The command-line `--init` flag still overrides the config file setting.
+
 ## State Management
 
 autowt stores its state in platform-appropriate directories:

--- a/src/autowt/cli.py
+++ b/src/autowt/cli.py
@@ -62,6 +62,10 @@ class AutowtGroup(click.Group):
             state_service, git_service, terminal_service, process_service = (
                 create_services()
             )
+
+            # Get init_script from command line args
+            init_script = kwargs.get("init")
+
             checkout_branch(
                 cmd_name,
                 terminal_mode,
@@ -69,7 +73,7 @@ class AutowtGroup(click.Group):
                 git_service,
                 terminal_service,
                 process_service,
-                init_script=kwargs.get("init"),
+                init_script=init_script,
             )
 
         # Create a new command with the same options as switch

--- a/src/autowt/commands/checkout.py
+++ b/src/autowt/commands/checkout.py
@@ -34,8 +34,13 @@ def checkout_branch(
 
     # Load configuration and state
     config = state_service.load_config()
+    project_config = state_service.load_project_config(repo_path)
     state = state_service.load_state(repo_path)
     session_ids = state_service.load_session_ids()
+
+    # Use project config init as default if no init_script provided
+    if init_script is None:
+        init_script = project_config.init
 
     # Use provided terminal mode or fall back to config
     if terminal_mode is None:

--- a/src/autowt/models.py
+++ b/src/autowt/models.py
@@ -68,6 +68,26 @@ class Configuration:
 
 
 @dataclass
+class ProjectConfig:
+    """Project-specific configuration."""
+
+    init: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ProjectConfig":
+        """Create project configuration from dictionary."""
+        return cls(
+            init=data.get("init"),
+        )
+
+    def to_dict(self) -> dict:
+        """Convert project configuration to dictionary."""
+        return {
+            "init": self.init,
+        }
+
+
+@dataclass
 class ApplicationState:
     """Main application state."""
 

--- a/src/autowt/services/state.py
+++ b/src/autowt/services/state.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import toml
 
-from autowt.models import ApplicationState, Configuration
+from autowt.models import ApplicationState, Configuration, ProjectConfig
 
 logger = logging.getLogger(__name__)
 
@@ -101,6 +101,30 @@ class StateService:
         except Exception as e:
             logger.error(f"Failed to load configuration: {e}")
             return Configuration()
+
+    def load_project_config(self, cwd: Path) -> ProjectConfig:
+        """Load project configuration from autowt.toml or .autowt.toml in current directory."""
+        logger.debug(f"Loading project configuration from {cwd}")
+
+        # Check for autowt.toml first, then .autowt.toml
+        config_files = [cwd / "autowt.toml", cwd / ".autowt.toml"]
+
+        for config_file in config_files:
+            if config_file.exists():
+                logger.debug(f"Found project config file: {config_file}")
+                try:
+                    data = toml.load(config_file)
+                    config = ProjectConfig.from_dict(data)
+                    logger.debug("Project configuration loaded successfully")
+                    return config
+                except Exception as e:
+                    logger.error(
+                        f"Failed to load project configuration from {config_file}: {e}"
+                    )
+                    continue
+
+        logger.debug("No project config file found, using defaults")
+        return ProjectConfig()
 
     def save_config(self, config: Configuration) -> None:
         """Save application configuration."""

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -7,6 +7,7 @@ from autowt.models import (
     BranchStatus,
     Configuration,
     ProcessInfo,
+    ProjectConfig,
     TerminalMode,
     WorktreeInfo,
 )
@@ -18,6 +19,7 @@ class MockStateService:
     def __init__(self):
         self.states: dict[str, ApplicationState] = {}
         self.configs: dict[str, Configuration] = {}
+        self.project_configs: dict[str, ProjectConfig] = {}
         self.session_ids: dict[str, str] = {}
         self.save_called = False
         self.load_called = False
@@ -38,6 +40,13 @@ class MockStateService:
 
     def save_config(self, config: Configuration) -> None:
         self.configs["default"] = config
+
+    def load_project_config(self, repo_path: Path) -> ProjectConfig:
+        key = str(repo_path)
+        return self.project_configs.get(key, ProjectConfig())
+
+    def save_project_config(self, repo_path: Path, config: ProjectConfig) -> None:
+        self.project_configs[str(repo_path)] = config
 
     def load_session_ids(self) -> dict[str, str]:
         return self.session_ids.copy()


### PR DESCRIPTION
## Summary
- Add ProjectConfig model for project-specific settings
- Support autowt.toml and .autowt.toml in project root  
- Add init field to specify default init script for worktrees
- Command-line --init flag still overrides config file
- Update README with project configuration documentation

## Test plan
- [x] All existing tests pass
- [x] Mock services updated to support ProjectConfig
- [x] Code formatted and linted
- [x] README updated with new feature documentation

🤖 Generated with [Claude Code](https://claude.ai/code)