### PR TITLE
Add Windows compatibility with graceful fallbacks

### DIFF
--- a/src/autowt/services/process.py
+++ b/src/autowt/services/process.py
@@ -1,6 +1,7 @@
 """Process management service for autowt."""
 
 import logging
+import platform
 import time
 from pathlib import Path
 
@@ -21,6 +22,10 @@ class ProcessService:
     def find_processes_in_directory(self, directory: Path) -> list[ProcessInfo]:
         """Find all processes running in the specified directory."""
         logger.debug(f"Finding processes in directory: {directory}")
+
+        if platform.system() == "Windows":
+            logger.info("Windows process discovery not yet supported - skipping")
+            return []
 
         processes = []
 
@@ -108,6 +113,10 @@ class ProcessService:
         """Terminate the given processes with SIGINT then SIGKILL if needed."""
         if not processes:
             logger.debug("No processes to terminate")
+            return True
+
+        if platform.system() == "Windows":
+            logger.info("Windows process termination not yet supported - skipping")
             return True
 
         logger.info(f"Terminating {len(processes)} processes")
@@ -201,6 +210,10 @@ class ProcessService:
 
     def _is_process_running(self, pid: int) -> bool:
         """Check if a process is still running."""
+        if platform.system() == "Windows":
+            # On Windows, we skip process discovery so we won't have PIDs to check
+            return False
+
         try:
             result = run_command(
                 ["ps", "-p", str(pid)],

--- a/src/autowt/services/terminal.py
+++ b/src/autowt/services/terminal.py
@@ -309,6 +309,10 @@ class GenericTerminal(Terminal):
                     timeout=10,
                     description=f"Open Terminal app at {worktree_path}",
                 )
+            elif platform.system() == "Windows":
+                # Windows terminal operations not yet supported
+                logger.info("Windows terminal operations not yet supported - skipping")
+                return False
             else:
                 # Try common Linux terminal emulators
                 terminals = ["gnome-terminal", "konsole", "xterm"]


### PR DESCRIPTION
## Summary
- Add Windows platform detection to skip unsupported terminal and process operations
- Log informative messages when Windows operations are skipped instead of crashing
- Preserve all existing Unix/macOS functionality unchanged
- Enable core git worktree functionality to work on Windows

## Changes Made
- **Terminal Service**: Skip terminal opening on Windows with log message
- **Process Service**: Skip process discovery, termination, and status checking on Windows with log messages
- **Platform Detection**: Added proper Windows detection using `platform.system()`

## Test plan
- [x] All existing tests pass (74 passed, 10 skipped)
- [x] Linting and formatting checks pass
- [x] No breaking changes to Unix/macOS functionality
- [x] Windows users get informative log messages instead of crashes

🤖 Generated with [Claude Code](https://claude.ai/code)