### PR TITLE
Fix iTerm2 session management and add --ignore-same-session flag

### DIFF
--- a/src/autowt/commands/checkout.py
+++ b/src/autowt/commands/checkout.py
@@ -23,6 +23,7 @@ def checkout_branch(
     terminal_service: TerminalService,
     process_service: ProcessService,
     init_script: str | None = None,
+    ignore_same_session: bool = False,
 ) -> None:
     """Switch to or create a worktree for the specified branch."""
     logger.debug(f"Checking out branch: {branch}")
@@ -58,26 +59,23 @@ def checkout_branch(
             break
 
     if existing_worktree:
-        # Switch to existing worktree - the terminal service handles prompting
+        # Switch to existing worktree - no init script needed (worktree already set up)
         session_id = session_ids.get(branch)
         success = terminal_service.switch_to_worktree(
             existing_worktree.path,
             terminal_mode,
             session_id,
-            init_script,
+            None,  # No init script for existing worktrees
             branch_name=branch,
             auto_confirm=options.auto_confirm,
+            ignore_same_session=ignore_same_session,
         )
 
         if not success:
             print_error(f"Failed to switch to {branch} worktree")
             return
 
-        # Update session ID if we're in a terminal that supports it
-        current_session = terminal_service.get_current_session_id()
-        if current_session:
-            session_ids[branch] = current_session
-            state_service.save_session_ids(session_ids)
+        # Session ID will be registered by the new tab itself
 
         return
 
@@ -92,6 +90,7 @@ def checkout_branch(
         terminal_service,
         state_service,
         init_script,
+        ignore_same_session,
     )
 
 
@@ -105,6 +104,7 @@ def _create_new_worktree(
     terminal_service: TerminalService,
     state_service: StateService,
     init_script: str | None = None,
+    ignore_same_session: bool = False,
 ) -> None:
     """Create a new worktree for the branch."""
     print_info("Fetching branches...")
@@ -125,24 +125,25 @@ def _create_new_worktree(
 
     # Switch to the new worktree
     success = terminal_service.switch_to_worktree(
-        worktree_path, terminal_mode, None, init_script
+        worktree_path,
+        terminal_mode,
+        None,
+        init_script,
+        branch_name=branch,
+        ignore_same_session=ignore_same_session,
     )
 
     if not success:
         print_error("Worktree created but failed to switch terminals")
         return
 
-    # Save session ID if available
-    current_session = terminal_service.get_current_session_id()
-    if current_session:
-        session_ids[branch] = current_session
-        state_service.save_session_ids(session_ids)
+    # Session ID will be registered by the new tab itself
 
     # Update state
     new_worktree = WorktreeInfo(
         branch=branch,
         path=worktree_path,
-        session_id=current_session,
+        session_id=None,  # Will be updated when session is registered
     )
     state.worktrees.append(new_worktree)
     state.current_worktree = branch

--- a/src/autowt/services/terminal.py
+++ b/src/autowt/services/terminal.py
@@ -49,6 +49,10 @@ class Terminal(ABC):
         """Whether this terminal supports session management."""
         return False
 
+    def session_exists(self, session_id: str) -> bool:
+        """Check if a session exists in the terminal."""
+        return False
+
     def _escape_for_applescript(self, text: str) -> str:
         """Escape text for use in AppleScript strings."""
         return text.replace("\\", "\\\\").replace('"', '\\"')
@@ -82,6 +86,38 @@ class Terminal(ABC):
             logger.error(f"Failed to run AppleScript: {e}")
             return False
 
+    def _run_applescript_with_result(self, script: str) -> bool:
+        """Execute AppleScript and return success status based on output."""
+        if not self.is_macos:
+            logger.warning("AppleScript not available on this platform")
+            return False
+
+        try:
+            result = run_command(
+                ["osascript", "-e", script],
+                timeout=30,
+                description="Execute AppleScript for terminal switching",
+            )
+
+            if result.returncode != 0:
+                logger.error(f"AppleScript failed: {result.stderr}")
+                return False
+
+            # Check if the output indicates success
+            output = result.stdout.strip().lower()
+            success = output == "true"
+
+            if success:
+                logger.debug("AppleScript executed successfully and returned true")
+            else:
+                logger.debug(f"AppleScript executed but returned: {output}")
+
+            return success
+
+        except Exception as e:
+            logger.error(f"Failed to run AppleScript: {e}")
+            return False
+
 
 class ITerm2Terminal(Terminal):
     """iTerm2 terminal implementation."""
@@ -95,6 +131,32 @@ class ITerm2Terminal(Terminal):
     def supports_session_management(self) -> bool:
         """iTerm2 supports session management."""
         return True
+
+    def session_exists(self, session_id: str) -> bool:
+        """Check if a session exists in iTerm2."""
+        if not session_id:
+            return False
+
+        # Extract UUID part from session ID (format: w0t0p2:UUID)
+        session_uuid = session_id.split(":")[-1] if ":" in session_id else session_id
+        logger.debug(f"Checking if session exists: {session_uuid}")
+
+        applescript = f'''
+        tell application "iTerm2"
+            repeat with theWindow in windows
+                repeat with theTab in tabs of theWindow
+                    repeat with theSession in sessions of theTab
+                        if id of theSession is "{session_uuid}" then
+                            return true
+                        end if
+                    end repeat
+                end repeat
+            end repeat
+            return false
+        end tell
+        '''
+
+        return self._run_applescript_with_result(applescript)
 
     def switch_to_session(
         self, session_id: str, init_script: str | None = None
@@ -117,7 +179,9 @@ class ITerm2Terminal(Terminal):
 
         if init_script:
             applescript += f'''
-                            write text "{self._escape_for_applescript(init_script)}" to theSession'''
+                            tell theSession
+                                write text "{self._escape_for_applescript(init_script)}"
+                            end tell'''
 
         applescript += """
                             return
@@ -134,7 +198,25 @@ class ITerm2Terminal(Terminal):
         """Open a new iTerm2 tab."""
         logger.debug(f"Opening new iTerm2 tab for {worktree_path}")
 
+        # Get the path to the current autowt executable
+        import shlex
+        import sys
+
+        autowt_path = sys.argv[0]
+        if not autowt_path.startswith("/"):
+            # If relative path, make it absolute
+            import os
+
+            autowt_path = os.path.abspath(autowt_path)
+
+        # Escape the autowt_path for shell execution
+        escaped_autowt_path = shlex.quote(autowt_path)
+
         commands = [f"cd {self._escape_path_for_command(worktree_path)}"]
+
+        # Add session registration command (uses current working directory)
+        commands.append(f"{escaped_autowt_path} register-session-for-path")
+
         if init_script:
             commands.append(init_script)
 
@@ -171,6 +253,88 @@ class ITerm2Terminal(Terminal):
         """
 
         return self._run_applescript(applescript)
+
+    def _run_applescript_for_output(self, script: str) -> str | None:
+        """Execute AppleScript and return the output string."""
+        if not self.is_macos:
+            logger.warning("AppleScript not available on this platform")
+            return None
+
+        try:
+            result = run_command(
+                ["osascript", "-e", script],
+                timeout=30,
+                description="Execute AppleScript for output",
+            )
+
+            if result.returncode != 0:
+                logger.error(f"AppleScript failed: {result.stderr}")
+                return None
+
+            return result.stdout.strip()
+
+        except Exception as e:
+            logger.error(f"Failed to run AppleScript: {e}")
+            return None
+
+    def list_sessions_with_directories(self) -> list[dict[str, str]]:
+        """List all iTerm2 sessions with their working directories."""
+        applescript = """
+        tell application "iTerm2"
+            set sessionData to ""
+            repeat with theWindow in windows
+                repeat with theTab in tabs of theWindow
+                    repeat with theSession in sessions of theTab
+                        try
+                            set sessionId to id of theSession
+                            set sessionPath to (variable named "session.path") of theSession
+                            if sessionData is not "" then
+                                set sessionData to sessionData & return
+                            end if
+                            set sessionData to sessionData & sessionId & "|" & sessionPath
+                        on error
+                            if sessionData is not "" then
+                                set sessionData to sessionData & return
+                            end if
+                            set sessionData to sessionData & sessionId & "|unknown"
+                        end try
+                    end repeat
+                end repeat
+            end repeat
+            return sessionData
+        end tell
+        """
+
+        output = self._run_applescript_for_output(applescript)
+        if not output:
+            return []
+
+        sessions = []
+        # Output format: "session1|/path1\nsession2|/path2\n..."
+        for line in output.split("\n"):
+            line = line.strip()
+            if line and "|" in line:
+                session_id, path = line.split("|", 1)
+                sessions.append(
+                    {
+                        "session_id": session_id.strip(),
+                        "working_directory": path.strip(),
+                    }
+                )
+
+        return sessions
+
+    def find_session_by_working_directory(self, target_path: str) -> str | None:
+        """Find a session ID that matches the given working directory."""
+        sessions = self.list_sessions_with_directories()
+        target_path = str(Path(target_path).resolve())  # Normalize path
+
+        for session in sessions:
+            session_path = str(Path(session["working_directory"]).resolve())
+            if session_path == target_path:
+                return session["session_id"]
+
+        return None
 
 
 class TerminalAppTerminal(Terminal):
@@ -1349,6 +1513,7 @@ class TerminalService:
         init_script: str | None = None,
         branch_name: str | None = None,
         auto_confirm: bool = False,
+        ignore_same_session: bool = False,
     ) -> bool:
         """Switch to a worktree using the specified terminal mode."""
         logger.debug(f"Switching to worktree {worktree_path} with mode {mode}")
@@ -1357,11 +1522,21 @@ class TerminalService:
             return self._change_directory_inplace(worktree_path, init_script)
         elif mode == TerminalMode.TAB:
             return self._switch_to_existing_or_new_tab(
-                worktree_path, session_id, init_script, branch_name, auto_confirm
+                worktree_path,
+                session_id,
+                init_script,
+                branch_name,
+                auto_confirm,
+                ignore_same_session,
             )
         elif mode == TerminalMode.WINDOW:
             return self._switch_to_existing_or_new_window(
-                worktree_path, session_id, init_script, branch_name, auto_confirm
+                worktree_path,
+                session_id,
+                init_script,
+                branch_name,
+                auto_confirm,
+                ignore_same_session,
             )
         else:
             logger.error(f"Unknown terminal mode: {mode}")
@@ -1392,28 +1567,54 @@ class TerminalService:
         init_script: str | None = None,
         branch_name: str | None = None,
         auto_confirm: bool = False,
+        ignore_same_session: bool = False,
     ) -> bool:
         """Switch to existing session or create new tab."""
-        # For Terminal.app, use worktree path as session identifier
-        # For other terminals (iTerm2, tmux), use provided session_id
-        if self.terminal.supports_session_management():
-            if isinstance(self.terminal, TerminalAppTerminal):
-                effective_session_id = str(worktree_path)
-            else:
-                effective_session_id = session_id
+        # If ignore_same_session is True, skip session detection and always create new tab
+        if not ignore_same_session:
+            # For Terminal.app, use worktree path as session identifier
+            # For other terminals (iTerm2, tmux), use provided session_id
+            if self.terminal.supports_session_management():
+                if isinstance(self.terminal, TerminalAppTerminal):
+                    effective_session_id = str(worktree_path)
+                else:
+                    effective_session_id = session_id
 
-            if effective_session_id:
-                if auto_confirm or self._should_switch_to_existing(branch_name):
-                    # Try to switch to existing session
-                    if self.terminal.switch_to_session(
-                        effective_session_id, init_script
-                    ):
-                        print(
-                            f"Switched to existing {branch_name or 'worktree'} session"
+                # First try: Check if the stored session ID exists
+                if effective_session_id and self.terminal.session_exists(
+                    effective_session_id
+                ):
+                    if auto_confirm or self._should_switch_to_existing(branch_name):
+                        # Try to switch to existing session (no init script - session already exists)
+                        if self.terminal.switch_to_session(effective_session_id, None):
+                            print(
+                                f"Switched to existing {branch_name or 'worktree'} session"
+                            )
+                            return True
+
+                # Second try: For iTerm2, check if there's a session in the worktree directory
+                if isinstance(self.terminal, ITerm2Terminal) and hasattr(
+                    self.terminal, "find_session_by_working_directory"
+                ):
+                    fallback_session_id = (
+                        self.terminal.find_session_by_working_directory(
+                            str(worktree_path)
                         )
-                        return True
+                    )
+                    if fallback_session_id:
+                        logger.debug(
+                            f"Found session {fallback_session_id} in directory {worktree_path}"
+                        )
+                        if auto_confirm or self._should_switch_to_existing(branch_name):
+                            if self.terminal.switch_to_session(
+                                fallback_session_id, None
+                            ):
+                                print(
+                                    f"Switched to existing {branch_name or 'worktree'} session (found by directory)"
+                                )
+                                return True
 
-        # Fall back to creating new tab
+        # Fall back to creating new tab (or forced by ignore_same_session)
         return self.terminal.open_new_tab(worktree_path, init_script)
 
     def _switch_to_existing_or_new_window(
@@ -1423,28 +1624,54 @@ class TerminalService:
         init_script: str | None = None,
         branch_name: str | None = None,
         auto_confirm: bool = False,
+        ignore_same_session: bool = False,
     ) -> bool:
         """Switch to existing session or create new window."""
-        # For Terminal.app, use worktree path as session identifier
-        # For other terminals (iTerm2, tmux), use provided session_id
-        if self.terminal.supports_session_management():
-            if isinstance(self.terminal, TerminalAppTerminal):
-                effective_session_id = str(worktree_path)
-            else:
-                effective_session_id = session_id
+        # If ignore_same_session is True, skip session detection and always create new window
+        if not ignore_same_session:
+            # For Terminal.app, use worktree path as session identifier
+            # For other terminals (iTerm2, tmux), use provided session_id
+            if self.terminal.supports_session_management():
+                if isinstance(self.terminal, TerminalAppTerminal):
+                    effective_session_id = str(worktree_path)
+                else:
+                    effective_session_id = session_id
 
-            if effective_session_id:
-                if auto_confirm or self._should_switch_to_existing(branch_name):
-                    # Try to switch to existing session
-                    if self.terminal.switch_to_session(
-                        effective_session_id, init_script
-                    ):
-                        print(
-                            f"Switched to existing {branch_name or 'worktree'} session"
+                # First try: Check if the stored session ID exists
+                if effective_session_id and self.terminal.session_exists(
+                    effective_session_id
+                ):
+                    if auto_confirm or self._should_switch_to_existing(branch_name):
+                        # Try to switch to existing session (no init script - session already exists)
+                        if self.terminal.switch_to_session(effective_session_id, None):
+                            print(
+                                f"Switched to existing {branch_name or 'worktree'} session"
+                            )
+                            return True
+
+                # Second try: For iTerm2, check if there's a session in the worktree directory
+                if isinstance(self.terminal, ITerm2Terminal) and hasattr(
+                    self.terminal, "find_session_by_working_directory"
+                ):
+                    fallback_session_id = (
+                        self.terminal.find_session_by_working_directory(
+                            str(worktree_path)
                         )
-                        return True
+                    )
+                    if fallback_session_id:
+                        logger.debug(
+                            f"Found session {fallback_session_id} in directory {worktree_path}"
+                        )
+                        if auto_confirm or self._should_switch_to_existing(branch_name):
+                            if self.terminal.switch_to_session(
+                                fallback_session_id, None
+                            ):
+                                print(
+                                    f"Switched to existing {branch_name or 'worktree'} session (found by directory)"
+                                )
+                                return True
 
-        # Fall back to creating new window
+        # Fall back to creating new window (or forced by ignore_same_session)
         return self.terminal.open_new_window(worktree_path, init_script)
 
     def _should_switch_to_existing(self, branch_name: str | None) -> bool:

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -150,9 +150,18 @@ class MockTerminalService:
         init_script: str | None = None,
         branch_name: str | None = None,
         auto_confirm: bool = False,
+        ignore_same_session: bool = False,
     ) -> bool:
         self.switch_calls.append(
-            (worktree_path, mode, session_id, init_script, branch_name, auto_confirm)
+            (
+                worktree_path,
+                mode,
+                session_id,
+                init_script,
+                branch_name,
+                auto_confirm,
+                ignore_same_session,
+            )
         )
         return self.switch_success
 

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -206,13 +206,16 @@ class TestCheckoutCommand:
                 init_script="setup.sh",
             )
 
-        # Verify terminal switching was called with init script
+        # Verify terminal switching was called WITHOUT init script (existing worktree)
         assert len(terminal_service.switch_calls) == 1
         call = terminal_service.switch_calls[0]
         assert call[0] == sample_worktrees[0].path  # worktree path
         assert call[1] == TerminalMode.TAB  # terminal mode
         assert call[2] == "session1"  # session ID
-        assert call[3] == "setup.sh"  # init script
+        assert call[3] is None  # no init script for existing worktrees
+        assert call[4] == "feature1"  # branch name
+        assert call[5] is False  # auto_confirm
+        assert call[6] is False  # ignore_same_session
 
     def test_checkout_new_worktree_with_init_script(self, temp_repo_path):
         """Test creating new worktree with init script."""

--- a/tests/unit/test_terminal_init_scripts.py
+++ b/tests/unit/test_terminal_init_scripts.py
@@ -144,10 +144,11 @@ class TestTerminalServiceInitScripts:
             )
 
             assert success
-            # Should try to switch to session first, then fall back to new tab
+            # Should try to switch to session first (no init script), then fall back to new tab
             mock_should_switch.assert_called_once_with("test-branch")
             mock_terminal.switch_to_session.assert_called_once_with(
-                "session-id", self.init_script
+                "session-id",
+                None,  # No init script when switching to existing session
             )
             mock_terminal.open_new_tab.assert_called_once_with(
                 self.test_path, self.init_script


### PR DESCRIPTION
## Summary
- Fix AppleScript syntax errors that prevented tab switching from working
- Add proper session existence validation to prevent false prompts for terminated sessions  
- Implement self-registration system for new tabs to capture correct session IDs
- Fix init script logic to only run for new worktrees, not when switching to existing ones
- Add `--ignore-same-session` flag to always create new terminals when desired

## Test plan
- [x] Fixed AppleScript syntax error that caused "Expected end of line, etc. but found 'to'" 
- [x] Session detection now properly validates sessions exist before prompting
- [x] New tabs self-register their session IDs instead of capturing wrong session
- [x] Init scripts only run for new worktrees, not existing worktree switches
- [x] `--ignore-same-session` flag bypasses session detection and always creates new terminals
- [x] All existing tests updated and passing
- [x] Manual testing confirms both session switching and new tab creation work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)