### PR TITLE
Fix all inline import violations (PLC0415)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ target-version = "py310"
 select = ["E", "F", "I", "N", "W", "UP"]
 ignore = ["E501"]
 # Enforce that imports are at the top of files
-extend-select = ["E402"]
+extend-select = ["E402", "PLC0415"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/src/autowt/cli.py
+++ b/src/autowt/cli.py
@@ -1,6 +1,8 @@
 """Main CLI entry point for autowt."""
 
 import logging
+import os
+from pathlib import Path
 
 import click
 
@@ -167,9 +169,6 @@ def register_session_for_path(debug: bool) -> None:
     session_id = terminal_service.get_current_session_id()
     if session_id:
         # Extract branch name from current working directory
-        import os
-        from pathlib import Path
-
         worktree_path = Path(os.getcwd())
         branch_name = worktree_path.name
 

--- a/src/autowt/commands/checkout.py
+++ b/src/autowt/commands/checkout.py
@@ -154,8 +154,6 @@ def _create_new_worktree(
 
 def _generate_worktree_path(repo_path: Path, branch: str) -> Path:
     """Generate a path for the new worktree."""
-    from autowt.services.git import GitService
-
     # Find the main repository path (not a worktree)
     git_service = GitService()
     worktrees = git_service.list_worktrees(repo_path)

--- a/src/autowt/commands/cleanup.py
+++ b/src/autowt/commands/cleanup.py
@@ -271,8 +271,6 @@ def _remove_worktrees_and_update_state(
             for branch in successfully_removed_branches:
                 print(f"  - {branch}")
 
-            from autowt.prompts import confirm_default_yes
-
             should_delete_branches = confirm_default_yes("Delete these local branches?")
 
         if should_delete_branches:

--- a/src/autowt/services/terminal.py
+++ b/src/autowt/services/terminal.py
@@ -4,12 +4,13 @@ import logging
 import os
 import platform
 import shlex
+import sys
 from abc import ABC, abstractmethod
 from pathlib import Path
 
 from autowt.models import TerminalMode
 from autowt.prompts import confirm_default_yes
-from autowt.utils import run_command
+from autowt.utils import run_command, sanitize_branch_name
 
 logger = logging.getLogger(__name__)
 
@@ -199,14 +200,9 @@ class ITerm2Terminal(Terminal):
         logger.debug(f"Opening new iTerm2 tab for {worktree_path}")
 
         # Get the path to the current autowt executable
-        import shlex
-        import sys
-
         autowt_path = sys.argv[0]
         if not autowt_path.startswith("/"):
             # If relative path, make it absolute
-            import os
-
             autowt_path = os.path.abspath(autowt_path)
 
         # Escape the autowt_path for shell execution
@@ -614,8 +610,6 @@ class TmuxTerminal(Terminal):
     def _create_session_name(self, worktree_path: Path) -> str:
         """Create a tmux session name for the worktree."""
         # Use sanitized worktree directory name
-        from autowt.utils import sanitize_branch_name
-
         return f"autowt-{sanitize_branch_name(worktree_path.name)}"
 
     def open_new_tab(self, worktree_path: Path, init_script: str | None = None) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from autowt.models import (
     TerminalMode,
     WorktreeInfo,
 )
+from tests.mocks.services import MockTerminalService
 
 
 @pytest.fixture
@@ -127,6 +128,4 @@ def mock_terminal_operations():
 @pytest.fixture
 def mock_terminal_service():
     """Provide a fully mocked terminal service."""
-    from tests.mocks.services import MockTerminalService
-
     return MockTerminalService()

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -1,6 +1,7 @@
 """Mock services for testing business logic."""
 
 from pathlib import Path
+from unittest.mock import Mock
 
 from autowt.models import (
     ApplicationState,
@@ -133,8 +134,6 @@ class MockTerminalService:
         self.switch_calls = []
 
         # Mock the terminal implementation
-        from unittest.mock import Mock
-
         self.terminal = Mock()
         self.terminal.get_current_session_id.return_value = self.current_session_id
         self.terminal.supports_session_management.return_value = True

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -6,6 +6,7 @@ import pytest
 from click.testing import CliRunner
 
 from autowt.cli import main
+from autowt.models import CleanupMode, TerminalMode
 
 
 class TestCLIRouting:
@@ -126,8 +127,6 @@ class TestCLIRouting:
             args, kwargs = mock_checkout.call_args
             assert args[0] == "feature-branch"  # branch name
             # args[1] should be the TerminalMode
-            from autowt.models import TerminalMode
-
             assert args[1] == TerminalMode.WINDOW
 
             mock_checkout.reset_mock()
@@ -216,8 +215,6 @@ class TestCLIRouting:
                 return_value=(Mock(), Mock(), Mock(), Mock()),
             ),
         ):
-            from autowt.models import CleanupMode
-
             # Test different modes
             for mode_str, mode_enum in [
                 ("all", CleanupMode.ALL),

--- a/tests/unit/test_console.py
+++ b/tests/unit/test_console.py
@@ -14,6 +14,7 @@ from autowt.console import (
     print_section,
     print_success,
 )
+from autowt.console import console as console2
 
 
 class TestConsoleTheme(unittest.TestCase):
@@ -103,8 +104,6 @@ class TestConsoleIntegration(unittest.TestCase):
 
     def test_console_is_singleton(self):
         """Test that console is a singleton instance."""
-        from autowt.console import console as console2
-
         self.assertIs(console, console2)
 
 


### PR DESCRIPTION
## Summary
- Enable PLC0415 rule in ruff configuration to catch imports inside functions
- Move all inline imports to top-level imports in 9 affected files
- Remove 13 total inline import violations across the codebase
- Improve code clarity, performance, and follow Python best practices

## Test plan
- [x] All tests pass (74 passed, 10 skipped)
- [x] All linting passes with new PLC0415 rule enabled
- [x] Code formatting is consistent
- [x] No functional changes - imports moved to module level only

🤖 Generated with [Claude Code](https://claude.ai/code)