### PR TITLE
Improve UX of autowt ls command

### DIFF
--- a/.claude/commands/submit.md
+++ b/.claude/commands/submit.md
@@ -48,9 +48,8 @@ Follow these steps to format, lint, commit, push, create a PR, and monitor CI:
    )"
    ```
 
-6. **Monitor CI (after brief delay):**
+6. **Monitor CI:**
    ```bash
-   sleep 10
    uv run cimonitor watch --pr [PR-NUMBER]
    ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ norecursedirs = ["scratch"]
 dev = [
     "pytest>=8.4.1",
     "ruff>=0.12.3",
-    "cimonitor>=0.1.4",
+    "cimonitor>=0.1.5",
     "pytest-cov>=6.2.1",
     "pre-commit>=3.0.0",
 ]

--- a/src/autowt/commands/ls.py
+++ b/src/autowt/commands/ls.py
@@ -1,9 +1,10 @@
 """List worktrees command."""
 
 import logging
+import shutil
 from pathlib import Path
 
-from autowt.console import print_error, print_plain, print_section
+from autowt.console import console, print_error, print_plain, print_section
 from autowt.models import Services
 
 logger = logging.getLogger(__name__)
@@ -29,47 +30,34 @@ def list_worktrees(services: Services) -> None:
     # Load session IDs
     session_ids = services.state.load_session_ids()
 
-    # Find the primary clone path
-    primary_clone_path = repo_path
-    for worktree in git_worktrees:
-        if worktree.is_primary:
-            primary_clone_path = worktree.path
-            break
-
-    print_plain(f"  Primary clone: {primary_clone_path}")
-
-    # Determine current location
-    current_location = "main clone"
+    # Determine which worktree we're currently in
+    current_worktree_path = None
     for worktree in git_worktrees:
         try:
             if current_path.is_relative_to(worktree.path):
-                # If we're in the primary worktree, it's the main clone
-                if worktree.is_primary:
-                    current_location = "main clone"
-                else:
-                    current_location = worktree.branch
+                current_worktree_path = worktree.path
                 break
         except ValueError:
             # is_relative_to raises ValueError if not relative
             continue
 
-    print_plain(f"  You are in: {current_location}")
-    print_plain("")
-
     if not git_worktrees:
         print_plain("  No worktrees found.")
         return
 
-    print_section("  Branches:")
+    print_section("  Worktrees:")
 
-    # Sort worktrees by branch name for consistent output
-    sorted_worktrees = sorted(git_worktrees, key=lambda w: w.branch)
+    # Sort worktrees: primary first, then by branch name
+    sorted_worktrees = sorted(git_worktrees, key=lambda w: (not w.is_primary, w.branch))
+
+    # Calculate the maximum terminal width to align branch names
+    terminal_width = 80  # Default fallback
+    try:
+        terminal_width = shutil.get_terminal_size().columns
+    except OSError:
+        pass
 
     for worktree in sorted_worktrees:
-        # Skip the main worktree (primary clone)
-        if worktree.path == repo_path:
-            continue
-
         branch = worktree.branch
         path = worktree.path
 
@@ -81,12 +69,45 @@ def list_worktrees(services: Services) -> None:
         except ValueError:
             display_path = str(path)
 
+        # Check if this is the current worktree
+        current_indicator = "→ " if current_worktree_path == worktree.path else "  "
+        branch_indicator = " ←" if current_worktree_path == worktree.path else "  "
+
         # Check if this branch has a session ID
         session_indicator = ""
         if branch in session_ids:
             session_indicator = " 💻"  # Laptop icon to indicate active session
 
-        print_plain(f"  {branch:<20} {display_path}{session_indicator}")
+        # Calculate base left part without main worktree indicator
+        base_left_part = f"{current_indicator}{display_path}{session_indicator}"
+
+        # Calculate length including main worktree indicator for alignment
+        main_indicator_text = " (main worktree)" if worktree.is_primary else ""
+        total_left_length = len(base_left_part) + len(main_indicator_text)
+
+        # Calculate space needed for right alignment
+        branch_with_indicator = f"{branch}{branch_indicator}"
+        if total_left_length + len(branch_with_indicator) + 2 < terminal_width:
+            spaces_needed = (
+                terminal_width - total_left_length - len(branch_with_indicator)
+            )
+            # Print with styled main worktree indicator
+            if worktree.is_primary:
+                console.print(
+                    f"{base_left_part}[dim grey50] (main worktree)[/dim grey50]{' ' * spaces_needed}{branch_with_indicator}"
+                )
+            else:
+                print_plain(
+                    f"{base_left_part}{' ' * spaces_needed}{branch_with_indicator}"
+                )
+        else:
+            # If line would be too long, just put branch on same line with minimal spacing
+            if worktree.is_primary:
+                console.print(
+                    f"{base_left_part}[dim grey50] (main worktree)[/dim grey50]  {branch_with_indicator}"
+                )
+            else:
+                print_plain(f"{base_left_part}  {branch_with_indicator}")
 
     print_plain("")
     print_plain("Use 'autowt <branch>' to switch to a worktree or create a new one.")

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "cimonitor", specifier = ">=0.1.4" },
+    { name = "cimonitor", specifier = ">=0.1.5" },
     { name = "pre-commit", specifier = ">=3.0.0" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
@@ -193,16 +193,16 @@ wheels = [
 
 [[package]]
 name = "cimonitor"
-version = "0.1.4"
+version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "gitpython" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/65/d7a073a483af9f93772691bc0d589f57fb8b2422f20db089fcccef40bac0/cimonitor-0.1.4.tar.gz", hash = "sha256:9fe0ca323b820c1f977d4c845f15a470dea593c8e5a811ac760b9b1625686a4f", size = 55174 }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/6a/c8ec57b876ef2c3847c6546a92200b76c2be65441f408d25d929b7387e09/cimonitor-0.1.5.tar.gz", hash = "sha256:10589bc8649d0e06679e2ee4a8170cf16a3b2fdd655e2d260c0adc9742743dfe", size = 59141 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/e2/9b527abcf03015134286e8a4a55af6795b2f2e69c79b71867dbef94b5eab/cimonitor-0.1.4-py3-none-any.whl", hash = "sha256:853d10ab2be5a3db077ab6c1a1a0c9a872c2302e1e119cc1a3a27b28ba8c9394", size = 20236 },
+    { url = "https://files.pythonhosted.org/packages/e7/9a/609586912d2764eb264d18d0effa9465c81350fda38348d63c16a4af7dc9/cimonitor-0.1.5-py3-none-any.whl", hash = "sha256:905611856a1b45d584c48d0fc28642069403c20d554ac64a987476f4f67f7895", size = 21966 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Remove first 2 lines (primary clone, you are in) for cleaner output
- Change "Branches:" header to "Worktrees:" and include main worktree in list  
- Add → and ← arrows to clearly indicate current worktree location
- Right-align branch names with proper terminal width calculation
- Show "(main worktree)" indicator in dim gray for primary worktree
- Add consistent spacing and padding for better visual alignment

## Test plan
- [x] Tested `uv run autowt ls` shows improved layout
- [x] Verified arrows correctly indicate current worktree
- [x] Confirmed main worktree is properly labeled and styled
- [x] Ensured right-aligned branch names work across terminal widths
- [x] Validated code passes linting and formatting checks

🤖 Generated with [Claude Code](https://claude.ai/code)