### PR TITLE
Improve process termination confirmation with detailed list

### DIFF
--- a/src/autowt/commands/cleanup.py
+++ b/src/autowt/commands/cleanup.py
@@ -247,17 +247,26 @@ def _handle_running_processes(
 
     dry_run_prefix = "[DRY RUN] " if dry_run else ""
 
-    # Show process summary (same as real execution)
-    if dry_run:
-        print(
-            f"{dry_run_prefix}Found {len(all_processes)} running processes that would be terminated:"
-        )
+    # Show list of processes that will be terminated
+    print(
+        f"\n{dry_run_prefix}Found {len(all_processes)} running processes in worktrees to be removed:"
+    )
+    for process in all_processes:
+        # Truncate long command lines for display
+        command = process.command
+        if len(command) > 80:
+            command = command[:77] + "..."
+        print(f"  PID {process.pid}: {command}")
+        print(f"    Working directory: {process.working_dir}")
 
-    process_service.print_process_summary(all_processes)
+    # Ask user for confirmation before killing processes (even in dry-run)
+    if not confirm_default_yes(f"\nTerminate these {len(all_processes)} processes?"):
+        print(f"{dry_run_prefix}Process termination cancelled.")
+        return False
 
     if dry_run:
         # In dry-run mode, simulate the termination
-        print(f"{dry_run_prefix}Would terminate {len(all_processes)} processes")
+        print(f"{dry_run_prefix}Would terminate these {len(all_processes)} processes")
         return True
     else:
         # Real execution - actually terminate processes


### PR DESCRIPTION
## Summary

Enhanced the process termination flow in cleanup to provide better user visibility and control. Users now see a detailed list of processes with PID, command name, and working directory before being asked for confirmation. The Y/n prompt defaults to Y and works consistently in both real execution and dry-run mode.

## Before
```
Shutting down processes operating in worktrees to be deleted...
  -zsh 41219
  ...done
```
Processes were automatically terminated without user confirmation.

## After  
```
Found 1 running processes in worktrees to be removed:
  PID 41219: -zsh
    Working directory: /Users/steve/dev/mcp/autowt-worktrees/testbranch-2

Terminate these 1 processes? (Y/n)
```

Users can now see exactly what processes will be affected and have the option to decline if they need to handle them manually first.

🤖 Generated with [Claude Code](https://claude.ai/code)