### PR TITLE
Remove unused list-sessions command

### DIFF
--- a/docs/clireference.md
+++ b/docs/clireference.md
@@ -84,4 +84,3 @@ These commands are for advanced use cases and troubleshooting.
 | Command | Description |
 | --- | --- |
 | `autowt register-session-for-path` | Manually registers the current terminal session for the current directory. |
-| `autowt list-sessions` | Lists all active terminal sessions that `autowt` is aware of. |

--- a/src/autowt/cli.py
+++ b/src/autowt/cli.py
@@ -260,36 +260,6 @@ def register_session_for_path(debug: bool) -> None:
 
 
 @main.command(
-    "list-sessions",
-    context_settings={"help_option_names": ["-h", "--help"]},
-)
-@click.option("--debug", is_flag=True, help="Enable debug logging")
-def list_sessions(debug: bool) -> None:
-    """List all terminal sessions with their working directories."""
-    setup_logging(debug)
-    services = create_services()
-
-    # Check if we have a terminal that supports session listing
-    if hasattr(services.terminal.terminal, "list_sessions_with_directories"):
-        sessions = services.terminal.terminal.list_sessions_with_directories()
-
-        if not sessions:
-            print("No sessions found or unable to retrieve session information.")
-            return
-
-        print("Terminal Sessions:")
-        print("-" * 80)
-        for session in sessions:
-            session_id = session["session_id"]
-            working_dir = session["working_directory"]
-            print(f"Session ID: {session_id}")
-            print(f"Working Directory: {working_dir}")
-            print("-" * 80)
-    else:
-        print("Current terminal does not support session listing.")
-
-
-@main.command(
     aliases=["list"], context_settings={"help_option_names": ["-h", "--help"]}
 )
 @click.option("--debug", is_flag=True, help="Enable debug logging")


### PR DESCRIPTION
## Summary
- Remove the unused `list-sessions` CLI command from the codebase
- Remove corresponding documentation reference in CLI reference guide
- Preserve underlying `list_sessions_with_directories` method as it's still used by core terminal session discovery functionality

## Test plan
- [x] All existing tests continue to pass (101 passed, 10 skipped)
- [x] Code formatting and linting checks pass
- [x] Verified no dead code remains - underlying session management functionality preserved

🤖 Generated with [Claude Code](https://claude.ai/code)