### PR TITLE
Improve shellconfig command with usage examples

### DIFF
--- a/src/autowt/cli.py
+++ b/src/autowt/cli.py
@@ -55,31 +55,29 @@ def _show_shell_config(shell_override: str | None = None) -> None:
 
     print("# Shell Integration for autowt")
     print(
-        "# Add this function to your shell configuration for convenient echo mode usage:"
+        "# Add this function to your shell configuration for convenient worktree switching:"
     )
     print()
 
     if shell == "fish":
         print("# Add to ~/.config/fish/config.fish:")
+        print("# Example usage: autowt_cd feature-branch")
         print("function autowt_cd")
         print("    eval (autowt $argv --terminal=echo)")
         print("end")
-        print()
-        print("# Then use: autowt_cd branch-name")
     elif shell in ["bash", "zsh"]:
         config_file = "~/.bashrc" if shell == "bash" else "~/.zshrc"
         print(f"# Add to {config_file}:")
+        print("# Example usage: autowt_cd feature-branch")
         print('autowt_cd() { eval "$(autowt "$@" --terminal=echo)"; }')
-        print()
-        print("# Then use: autowt_cd branch-name")
     elif shell in ["tcsh", "csh"]:
         config_file = "~/.tcshrc" if shell == "tcsh" else "~/.cshrc"
         print(f"# Add to {config_file}:")
+        print("# Example usage: autowt_cd feature-branch")
         print("alias autowt_cd 'eval `autowt \\!* --terminal=echo`'")
-        print()
-        print("# Then use: autowt_cd branch-name")
     elif shell == "nu":
         print("# Add to ~/.config/nushell/config.nu:")
+        print("# Example usage: autowt_cd feature-branch")
         print("def autowt_cd [...args] {")
         print(
             "    load-env (autowt ...$args --terminal=echo | parse 'export {name}={value}' | transpose -r)"
@@ -89,20 +87,16 @@ def _show_shell_config(shell_override: str | None = None) -> None:
         print(
             "# Note: nushell requires different syntax. You may need to adjust based on output format."
         )
-        print("# Alternatively, use: ^autowt branch-name --terminal=inplace (macOS)")
-        print("# Then use: autowt_cd branch-name")
     elif shell in ["oil", "osh"]:
         print("# Add to ~/.config/oil/oshrc:")
+        print("# Example usage: autowt_cd feature-branch")
         print('autowt_cd() { eval "$(autowt "$@" --terminal=echo)"; }')
-        print()
-        print("# Then use: autowt_cd branch-name")
     elif shell == "elvish":
         print("# Add to ~/.config/elvish/rc.elv:")
+        print("# Example usage: autowt_cd feature-branch")
         print("fn autowt_cd {|@args|")
         print("    eval (autowt $@args --terminal=echo)")
         print("}")
-        print()
-        print("# Then use: autowt_cd branch-name")
     else:
         # Comprehensive fallback for unknown shells
         print(
@@ -111,24 +105,21 @@ def _show_shell_config(shell_override: str | None = None) -> None:
         print()
         print("# POSIX-compatible shells (bash, zsh, dash, ash, etc.):")
         print("# Add to your shell's config file (e.g., ~/.bashrc, ~/.zshrc):")
+        print("# Example usage: autowt_cd feature-branch")
         print('autowt_cd() { eval "$(autowt "$@" --terminal=echo)"; }')
         print()
         print("# Fish shell - add to ~/.config/fish/config.fish:")
+        print("# Example usage: autowt_cd feature-branch")
         print("function autowt_cd")
         print("    eval (autowt $argv --terminal=echo)")
         print("end")
         print()
         print("# C shell variants (csh, tcsh) - add to ~/.cshrc or ~/.tcshrc:")
+        print("# Example usage: autowt_cd feature-branch")
         print("alias autowt_cd 'eval `autowt \\!* --terminal=echo`'")
         print()
         print("# For other shells, adapt the above patterns or use manual eval:")
         print('# eval "$(autowt branch-name --terminal=echo)"')
-        print()
-        print("# Then use: autowt_cd branch-name")
-
-    print()
-    print("# Alternatively, use --terminal=inplace for direct execution (macOS only):")
-    print("# autowt branch-name --terminal=inplace")
 
 
 # Custom Group class that handles unknown commands as branch names and supports aliases


### PR DESCRIPTION
Replace generic comments with concrete usage examples showing `autowt_cd feature-branch` to help users understand exactly what they'll type after adding the shell integration. Remove redundant inplace terminal option references for cleaner output.

🤖 Generated with [Claude Code](https://claude.ai/code)