### PR TITLE
Fix cleanup process kill confirmation prompt

### DIFF
--- a/.claude/commands/submit.md
+++ b/.claude/commands/submit.md
@@ -2,7 +2,7 @@
 
 1. `mise run format && mise run lint`, then fix issues
 2. `mise run tests`, then fix issues
-3. Review changes with `git status` and `git diff`, checking for commits vs the merge-base of origin/main, as well as unstaged cahnges, and staged changes
+3. Review changes with `git status` and `git --no-pager diff`, checking for commits vs the merge-base of origin/main, as well as unstaged cahnges, and staged changes
 4. Stage and commit changes:
 
    ```bash

--- a/docs/clireference.md
+++ b/docs/clireference.md
@@ -55,6 +55,12 @@ Safely removes worktrees, their directories, and associated local git branches. 
 
 Opens an interactive TUI to configure global `autowt` settings, such as the default terminal mode. Learn more in the [Configuration](configuration.md) guide.
 
+<div class="autowt-clitable-wrapper"></div>
+
+| Option | Description |
+|---|---|
+| `--show` | Display current configuration values from all sources (global and project). Useful for debugging configuration issues. |
+
 ### `autowt shellconfig`
 
 Displays a function you could choose to add to your shell config to cd to worktrees without needing autowt to control your terminal program. For example, if you use zsh, you'd see this:

--- a/src/autowt/cli.py
+++ b/src/autowt/cli.py
@@ -17,7 +17,7 @@ from autowt.commands.checkout import (
     find_waiting_agent_branch,
 )
 from autowt.commands.cleanup import cleanup_worktrees
-from autowt.commands.config import configure_settings
+from autowt.commands.config import configure_settings, show_config
 from autowt.commands.hooks import install_hooks_command, show_installed_hooks
 from autowt.commands.ls import list_worktrees
 from autowt.config import get_config
@@ -410,8 +410,8 @@ def cleanup(
         kill_processes = True
     elif no_kill:
         kill_processes = False
-    else:
-        kill_processes = config.cleanup.kill_processes
+    # Note: When no CLI flags are specified, pass None to allow prompting
+    # The cleanup logic will use config.cleanup.kill_processes for the default
 
     cleanup_cmd = CleanupCommand(
         mode=CleanupMode(mode),
@@ -429,12 +429,17 @@ def cleanup(
     context_settings={"help_option_names": ["-h", "--help"]},
 )
 @click.option("--debug", is_flag=True, help="Enable debug logging")
-def config(debug: bool) -> None:
+@click.option("--show", is_flag=True, help="Show current configuration values")
+def config(debug: bool, show: bool) -> None:
     """Configure autowt settings using interactive TUI."""
     setup_logging(debug)
     services = create_services()
     auto_register_session(services)
-    configure_settings(services)
+
+    if show:
+        show_config(services)
+    else:
+        configure_settings(services)
 
 
 @main.command(context_settings={"help_option_names": ["-h", "--help"]})

--- a/src/autowt/commands/cleanup.py
+++ b/src/autowt/commands/cleanup.py
@@ -109,7 +109,7 @@ def cleanup_worktrees(cleanup_cmd: CleanupCommand, services: Services) -> None:
             # No CLI flag specified: use config default, but still prompt if config says kill
             # If config says don't kill processes, auto-decline (like --no-kill)
             # If config says kill processes, prompt user (None)
-            auto_kill = None if config.cleanup_kill_processes else False
+            auto_kill = None if config.cleanup.kill_processes else False
 
         if not _handle_running_processes(
             to_cleanup, services.process, cleanup_cmd.dry_run, auto_kill

--- a/src/autowt/commands/config.py
+++ b/src/autowt/commands/config.py
@@ -179,6 +179,56 @@ class ConfigApp(App):
             self.exit()
 
 
+def show_config(services: Services) -> None:
+    """Show current configuration values."""
+    config = services.state.load_config()
+    config_loader = ConfigLoader(app_dir=services.state.app_dir)
+
+    print("Current Configuration:")
+    print("=" * 50)
+    print()
+
+    print("Terminal:")
+    print(f"  mode: {config.terminal.mode.value}")
+    print(f"  always_new: {config.terminal.always_new}")
+    print(f"  program: {config.terminal.program}")
+    print()
+
+    print("Worktree:")
+    print(f"  directory_pattern: {config.worktree.directory_pattern}")
+    print(f"  max_worktrees: {config.worktree.max_worktrees}")
+    print(f"  auto_fetch: {config.worktree.auto_fetch}")
+    print(f"  default_remote: {config.worktree.default_remote}")
+    print(f"  branch_sanitization: {config.worktree.branch_sanitization}")
+    print()
+
+    print("Cleanup:")
+    print(f"  kill_processes: {config.cleanup.kill_processes}")
+    print(f"  kill_process_timeout: {config.cleanup.kill_process_timeout}")
+    print(f"  default_mode: {config.cleanup.default_mode.value}")
+    print()
+
+    print("Scripts:")
+    print(f"  init: {config.scripts.init}")
+    if config.scripts.custom:
+        print("  custom:")
+        for name, script in config.scripts.custom.items():
+            print(f"    {name}: {script}")
+    else:
+        print("  custom: {}")
+    print()
+
+    print("Confirmations:")
+    print(f"  cleanup_multiple: {config.confirmations.cleanup_multiple}")
+    print(f"  kill_process: {config.confirmations.kill_process}")
+    print(f"  force_operations: {config.confirmations.force_operations}")
+    print()
+
+    print("Config Files:")
+    print(f"  Global: {config_loader.global_config_file}")
+    print("  Project: autowt.toml or .autowt.toml in repository root")
+
+
 def configure_settings(services: Services) -> None:
     """Configure autowt settings interactively."""
     logger.debug("Configuring settings")


### PR DESCRIPTION
The Y/n confirmation for killing processes during cleanup was being bypassed when no CLI flags were specified. The bug occurred because the CLI was passing the config value directly to the cleanup command instead of None, causing the cleanup logic to treat it as a CLI override.

This fix restores the expected behavior where users are prompted to confirm process termination unless they explicitly use --kill or --no-kill flags.

Also adds `autowt config --show` command to help debug configuration issues.

🤖 Generated with [Claude Code](https://claude.ai/code)