### PR TITLE
Fix session ID conflicts between repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# autowt: Supercharge your git workflow
+# autowt: a better git worktree experience
 
 **autowt** is a git worktree manager designed for developers who juggle multiple tasks. It automates the creation, management, and cleanup of git worktrees, giving each branch its own dedicated directory and terminal session. This eliminates context-switching friction, letting you focus on your code.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# autowt: Supercharge your git workflow
+# autowt: a better git worktree experience
 
 **autowt** is a git worktree manager designed for developers who juggle multiple tasks. It automates the creation, management, and cleanup of git worktrees, giving each branch its own dedicated directory and terminal tab or window. This eliminates context-switching friction, letting you focus on your code.
 

--- a/src/autowt/cli.py
+++ b/src/autowt/cli.py
@@ -70,13 +70,10 @@ def auto_register_session(services: Services) -> None:
         worktree_path = Path(os.getcwd())
         branch_name = services.git.get_current_branch(repo_path) or worktree_path.name
 
-        # Load existing session IDs to check if already registered
-        session_ids = services.state.load_session_ids()
-
         # Only register if not already registered for this branch
-        if branch_name not in session_ids or session_ids[branch_name] != session_id:
-            session_ids[branch_name] = session_id
-            services.state.save_session_ids(session_ids)
+        existing_session_id = services.state.get_session_id(repo_path, branch_name)
+        if existing_session_id != session_id:
+            services.state.set_session_id(repo_path, branch_name, session_id)
 
     except Exception:
         # Silently fail - session registration should never break the main command
@@ -322,10 +319,8 @@ def register_session_for_path(debug: bool) -> None:
             else worktree_path.name
         )
 
-        # Load and update session IDs
-        session_ids = services.state.load_session_ids()
-        session_ids[branch_name] = session_id
-        services.state.save_session_ids(session_ids)
+        # Set session ID for this repo/branch
+        services.state.set_session_id(repo_path, branch_name, session_id)
         print(
             f"Registered session {session_id} for branch {branch_name} (path: {worktree_path})"
         )

--- a/src/autowt/commands/cleanup.py
+++ b/src/autowt/commands/cleanup.py
@@ -373,10 +373,8 @@ def _remove_worktrees_and_update_state(
     else:
         # Real execution - update session IDs
         removed_branches = {bs.branch for bs in to_cleanup}
-        session_ids = services.state.load_session_ids()
         for branch in removed_branches:
-            session_ids.pop(branch, None)
-        services.state.save_session_ids(session_ids)
+            services.state.remove_session_id(repo_path, branch)
 
         print("Session IDs updated")
 

--- a/src/autowt/commands/ls.py
+++ b/src/autowt/commands/ls.py
@@ -135,12 +135,9 @@ def list_worktrees(services: Services, debug: bool = False) -> None:
 
         print_plain("")
 
-    # Load session IDs
-    session_ids = services.state.load_session_ids()
-
     # Enhance worktrees with agent status
     enhanced_worktrees = services.agent.enhance_worktrees_with_agent_status(
-        git_worktrees, session_ids
+        git_worktrees, services.state, repo_path
     )
 
     # Determine which worktree we're currently in

--- a/src/autowt/services/agent.py
+++ b/src/autowt/services/agent.py
@@ -82,14 +82,15 @@ class AgentService:
         return None
 
     def enhance_worktrees_with_agent_status(
-        self, worktrees: list[WorktreeInfo], session_ids: dict[str, str]
+        self, worktrees: list[WorktreeInfo], state_service, repo_path: Path
     ) -> list[WorktreeWithAgent]:
         """Add agent status to worktree information."""
         enhanced = []
 
         for worktree in worktrees:
             agent_status = self.detect_agent_status(worktree.path)
-            has_session = worktree.branch in session_ids
+            session_id = state_service.get_session_id(repo_path, worktree.branch)
+            has_session = session_id is not None
 
             enhanced.append(
                 WorktreeWithAgent(

--- a/src/autowt/tui/agents.py
+++ b/src/autowt/tui/agents.py
@@ -59,11 +59,10 @@ class AgentDashboard(App):
         """Refresh agent data from worktrees."""
         # Get worktrees
         git_worktrees = self.services.git.list_worktrees(self.repo_path)
-        session_ids = self.services.state.load_session_ids()
 
         # Enhance with agent status
         enhanced_worktrees = self.services.agent.enhance_worktrees_with_agent_status(
-            git_worktrees, session_ids
+            git_worktrees, self.services.state, self.repo_path
         )
 
         # Clear and populate table
@@ -102,9 +101,8 @@ class AgentDashboard(App):
         """Switch to first agent waiting for input."""
         # Find waiting agents
         git_worktrees = self.services.git.list_worktrees(self.repo_path)
-        session_ids = self.services.state.load_session_ids()
         enhanced_worktrees = self.services.agent.enhance_worktrees_with_agent_status(
-            git_worktrees, session_ids
+            git_worktrees, self.services.state, self.repo_path
         )
 
         waiting_agents = self.services.agent.find_waiting_agents(enhanced_worktrees)

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -70,7 +70,9 @@ class TestCheckoutCommand:
         """Test switching to existing worktree."""
         # Setup mocks
         services = MockServices()
-        services.state.session_ids = {"feature1": "session1"}  # Add session ID data
+        # Add session ID data using composite key format
+        composite_key = f"{temp_repo_path.resolve()}:feature1"
+        services.state.session_ids = {composite_key: "session1"}  # Add session ID data
         services.git.repo_root = temp_repo_path
         services.git.worktrees = sample_worktrees
 
@@ -174,7 +176,9 @@ class TestCheckoutCommand:
         """Test switching to existing worktree with init script."""
         # Setup mocks
         services = MockServices()
-        services.state.session_ids = {"feature1": "session1"}
+        # Add session ID data using composite key format
+        composite_key = f"{temp_repo_path.resolve()}:feature1"
+        services.state.session_ids = {composite_key: "session1"}
         services.git.repo_root = temp_repo_path
         services.git.worktrees = sample_worktrees
 

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "autowt"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes session ID collisions when autowt is used across multiple repositories with identically named branches.

Session IDs now use composite keys that include repository paths, ensuring proper isolation between different projects.

🤖 Generated with [Claude Code](https://claude.ai/code)