### PR TITLE
Add experimental terminal warning on first use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Added
 
+- Added experimental terminal warning on first use of unsupported terminals
+- First-run warning displays terminal name, GitHub source link, and issue reporting URL
+- User can confirm or decline to continue with experimental terminal support
+
 ### Changed
 
 ### Fixed

--- a/src/autowt/services/state.py
+++ b/src/autowt/services/state.py
@@ -192,3 +192,14 @@ class StateService:
         state = self.load_app_state()
         state["hooks_prompt_shown"] = True
         self.save_app_state(state)
+
+    def has_shown_experimental_terminal_warning(self) -> bool:
+        """Check if we have already shown the experimental terminal warning."""
+        state = self.load_app_state()
+        return state.get("experimental_terminal_warning_shown", False)
+
+    def mark_experimental_terminal_warning_shown(self) -> None:
+        """Mark that we have shown the experimental terminal warning."""
+        state = self.load_app_state()
+        state["experimental_terminal_warning_shown"] = True
+        self.save_app_state(state)

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "autowt"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Adds a user-friendly warning system for experimental terminal support. When users first encounter an unsupported terminal, they see a clear warning with their terminal name, a direct link to the implementation source code, and instructions for reporting issues.

The warning only appears once per installation and allows users to decline if they're not comfortable proceeding with experimental support.

🤖 Generated with [Claude Code](https://claude.ai/code)