### PR TITLE
Implement custom script argument interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### Added
 
+- Custom script argument interpolation with `--custom-script` option
+  - Run custom scripts with arguments: `autowt switch branch --custom-script="bugfix 123"`
+  - Arguments are interpolated into script templates using `$1`, `$2`, etc. placeholders
+  - Works with both new and existing worktrees
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Custom script argument interpolation with `--custom-script` option
   - Run custom scripts with arguments: `autowt switch branch --custom-script="bugfix 123"`
   - Arguments are interpolated into script templates using `$1`, `$2`, etc. placeholders
+  - Supports shell-style quoting for arguments with spaces: `--custom-script='deploy "staging env" --force'`
   - Works with both new and existing worktrees
 
 ### Changed

--- a/src/autowt/cli.py
+++ b/src/autowt/cli.py
@@ -243,6 +243,10 @@ class AutowtGroup(ClickAliasedGroup):
                     is_flag=True,
                     help="Always create new terminal, ignore existing sessions",
                 ),
+                click.Option(
+                    ["--custom-script"],
+                    help="Custom script to run with arguments (e.g., 'bugfix 123')",
+                ),
             ],
             help=f"Switch to or create a worktree for branch '{cmd_name}'",
         )
@@ -493,6 +497,10 @@ def shellconfig(debug: bool, shell: str | None) -> None:
     help="Switch to most recently active agent",
 )
 @click.option("--debug", is_flag=True, help="Enable debug logging")
+@click.option(
+    "--custom-script",
+    help="Custom script to run with arguments (e.g., 'bugfix 123')",
+)
 def switch(
     branch: str | None,
     terminal: str | None,
@@ -503,6 +511,7 @@ def switch(
     waiting: bool,
     latest: bool,
     debug: bool,
+    custom_script: str | None,
 ) -> None:
     """Switch to or create a worktree for the specified branch."""
     setup_logging(debug)
@@ -534,6 +543,7 @@ def switch(
         init=init,
         after_init=after_init,
         ignore_same_session=ignore_same_session,
+        custom_script=custom_script,
     )
 
     # Initialize configuration with CLI overrides
@@ -552,6 +562,7 @@ def switch(
         ignore_same_session=config.terminal.always_new or ignore_same_session,
         auto_confirm=auto_confirm,
         debug=debug,
+        custom_script=custom_script,
     )
     checkout_branch(switch_cmd, services)
 

--- a/src/autowt/cli_config.py
+++ b/src/autowt/cli_config.py
@@ -5,6 +5,7 @@ It provides utilities to convert CLI options to config overrides and initialize 
 """
 
 import logging
+import shlex
 from pathlib import Path
 from typing import Any
 
@@ -157,12 +158,22 @@ def resolve_custom_script_with_interpolation(script_spec: str) -> str | None:
         script_spec = "bugfix 123"
         config has: bugfix = 'claude "Fix bug described in issue $1"'
         returns: 'claude "Fix bug described in issue 123"'
+
+    Note:
+        Arguments are inserted directly without shell escaping to preserve shell features.
     """
     if not script_spec:
         return None
 
-    # Parse script name and arguments
-    parts = script_spec.split()
+    # Parse script name and arguments using shell-aware splitting
+    try:
+        parts = shlex.split(script_spec)
+    except ValueError as e:
+        logger.warning(
+            f"Invalid shell syntax in custom script spec '{script_spec}': {e}"
+        )
+        return None
+
     if not parts:
         return None
 

--- a/src/autowt/cli_config.py
+++ b/src/autowt/cli_config.py
@@ -143,6 +143,47 @@ def get_custom_script_from_config(script_name: str) -> str | None:
     return config.scripts.custom.get(script_name)
 
 
+def resolve_custom_script_with_interpolation(script_spec: str) -> str | None:
+    """Resolve a custom script specification with argument interpolation.
+
+    Args:
+        script_spec: Space-separated script specification like "bugfix 123"
+                    where first part is script name, rest are arguments
+
+    Returns:
+        The resolved script command with arguments interpolated, or None if script not found
+
+    Example:
+        script_spec = "bugfix 123"
+        config has: bugfix = 'claude "Fix bug described in issue $1"'
+        returns: 'claude "Fix bug described in issue 123"'
+    """
+    if not script_spec:
+        return None
+
+    # Parse script name and arguments
+    parts = script_spec.split()
+    if not parts:
+        return None
+
+    script_name = parts[0]
+    args = parts[1:]
+
+    # Get the script template from config
+    script_template = get_custom_script_from_config(script_name)
+    if not script_template:
+        logger.warning(f"Custom script '{script_name}' not found in configuration")
+        return None
+
+    # Perform argument interpolation
+    resolved_script = script_template
+    for i, arg in enumerate(args, 1):
+        placeholder = f"${i}"
+        resolved_script = resolved_script.replace(placeholder, arg)
+
+    return resolved_script
+
+
 def should_confirm_operation(operation_type: str) -> bool:
     """Check if an operation should require user confirmation.
 

--- a/src/autowt/models.py
+++ b/src/autowt/models.py
@@ -201,6 +201,7 @@ class SwitchCommand:
     ignore_same_session: bool = False
     auto_confirm: bool = False
     debug: bool = False
+    custom_script: str | None = None
 
 
 @dataclass


### PR DESCRIPTION
Add `--custom-script` option that enables running custom scripts with argument interpolation. Users can now run commands like `autowt switch branch --custom-script="bugfix 123"` where script templates use `$1`, `$2`, etc. placeholders that get replaced with provided arguments.

Supports shell-style quoting for complex arguments: `--custom-script='deploy "staging environment" --force'`

The feature works with both new and existing worktrees, combining custom scripts with existing init and after-init scripts.

🤖 Generated with [Claude Code](https://claude.ai/code)