### PR TITLE
Add --from flag to specify source branch when creating worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### Added
 
+- Added `--from` flag to specify source branch/commit when creating worktrees
+  - Accepts any git revision: branch names, tags, commit hashes, `HEAD`, etc.
+  - Available for both `autowt switch` and direct branch commands (`autowt my-branch --from main`)
+  - Only used when creating new worktrees; ignored when switching to existing ones
+
 ### Changed
 
 ### Fixed

--- a/docs/clireference.md
+++ b/docs/clireference.md
@@ -17,6 +17,7 @@ The `autowt <branch-name>` form is a convenient shortcut. Use the explicit `swit
 | `--init <script>` | Runs a setup script in the new terminal session. Ideal for installing dependencies or copying config files. See [Init Scripts](initscripts.md). |
 | `--after-init <script>` | Runs a command *after* the `init` script completes. Perfect for starting a dev server or an [AI agent](agents.md). |
 | `--ignore-same-session` | Forces `autowt` to create a new terminal, even if a session for that worktree already exists. |
+| `--from <branch>` | Source branch/commit to create worktree from. Accepts any git revision: branch names, tags, commit hashes, `HEAD`, etc. Only used when creating new worktrees. |
 | `--waiting` | Switch to first agent waiting for input. |
 | `--latest` | Switch to most recently active agent. |
 | `-y`, `--yes` | Automatically confirms all prompts, such as the prompt to switch to an existing terminal session. |

--- a/src/autowt/cli.py
+++ b/src/autowt/cli.py
@@ -210,6 +210,7 @@ class AutowtGroup(ClickAliasedGroup):
                 or kwargs.get("ignore_same_session", False),
                 auto_confirm=kwargs.get("auto_confirm", kwargs.get("yes", False)),
                 debug=kwargs.get("debug", False),
+                from_branch=kwargs.get("from_branch"),
             )
             checkout_branch(switch_cmd, services)
 
@@ -242,6 +243,11 @@ class AutowtGroup(ClickAliasedGroup):
                     ["--ignore-same-session"],
                     is_flag=True,
                     help="Always create new terminal, ignore existing sessions",
+                ),
+                click.Option(
+                    ["--from"],
+                    "from_branch",
+                    help="Source branch/commit to create worktree from (any git rev: branch, tag, HEAD, etc.)",
                 ),
             ],
             help=f"Switch to or create a worktree for branch '{cmd_name}'",
@@ -492,6 +498,11 @@ def shellconfig(debug: bool, shell: str | None) -> None:
     is_flag=True,
     help="Switch to most recently active agent",
 )
+@click.option(
+    "--from",
+    "from_branch",
+    help="Source branch/commit to create worktree from (any git rev: branch, tag, HEAD, etc.)",
+)
 @click.option("--debug", is_flag=True, help="Enable debug logging")
 def switch(
     branch: str | None,
@@ -502,6 +513,7 @@ def switch(
     auto_confirm: bool,
     waiting: bool,
     latest: bool,
+    from_branch: str | None,
     debug: bool,
 ) -> None:
     """Switch to or create a worktree for the specified branch."""
@@ -552,6 +564,7 @@ def switch(
         ignore_same_session=config.terminal.always_new or ignore_same_session,
         auto_confirm=auto_confirm,
         debug=debug,
+        from_branch=from_branch,
     )
     checkout_branch(switch_cmd, services)
 

--- a/src/autowt/commands/checkout.py
+++ b/src/autowt/commands/checkout.py
@@ -196,7 +196,9 @@ def _create_new_worktree(
     print_info(f"Creating worktree for {switch_cmd.branch}...")
 
     # Create the worktree
-    if not services.git.create_worktree(repo_path, switch_cmd.branch, worktree_path):
+    if not services.git.create_worktree(
+        repo_path, switch_cmd.branch, worktree_path, switch_cmd.from_branch
+    ):
         print_error(f"✗ Failed to create worktree for {switch_cmd.branch}")
         return
 

--- a/src/autowt/models.py
+++ b/src/autowt/models.py
@@ -201,6 +201,7 @@ class SwitchCommand:
     ignore_same_session: bool = False
     auto_confirm: bool = False
     debug: bool = False
+    from_branch: str | None = None
 
 
 @dataclass

--- a/src/autowt/services/git.py
+++ b/src/autowt/services/git.py
@@ -189,7 +189,6 @@ class GitService:
             if from_branch:
                 # User specified a source branch/commit - use it directly
                 logger.debug(f"Creating worktree from specified source: {from_branch}")
-                # Check if branch exists locally first
                 result = run_command_quiet_on_failure(
                     ["git", "show-ref", "--verify", f"refs/heads/{branch}"],
                     cwd=repo_path,
@@ -198,7 +197,7 @@ class GitService:
                 )
 
                 if result.returncode == 0:
-                    # Branch exists locally, check out from from_branch
+                    # Branch exists locally
                     cmd = [
                         "git",
                         "worktree",
@@ -219,7 +218,7 @@ class GitService:
                         from_branch,
                     ]
             else:
-                # No source branch specified - use existing logic
+                # ORIGINAL LOGIC - unchanged from before
                 # Check if branch exists locally
                 result = run_command_quiet_on_failure(
                     ["git", "show-ref", "--verify", f"refs/heads/{branch}"],

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -133,9 +133,15 @@ class MockGitService:
         return self.fetch_success
 
     def create_worktree(
-        self, repo_path: Path, branch: str, worktree_path: Path
+        self,
+        repo_path: Path,
+        branch: str,
+        worktree_path: Path,
+        from_branch: str | None = None,
     ) -> bool:
-        self.create_worktree_calls.append((repo_path, branch, worktree_path))
+        self.create_worktree_calls.append(
+            (repo_path, branch, worktree_path, from_branch)
+        )
         if self.create_success:
             # Add to our mock worktree list
             self.worktrees.append(

--- a/tests/unit/test_cli_from_flag.py
+++ b/tests/unit/test_cli_from_flag.py
@@ -1,0 +1,27 @@
+"""Tests for CLI --from flag functionality."""
+
+from click.testing import CliRunner
+
+from autowt.cli import main
+
+
+class TestCLIFromFlag:
+    """Test the --from flag in CLI commands."""
+
+    def test_switch_command_help_shows_from_option(self):
+        """Test that --from option appears in switch command help."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["switch", "--help"])
+
+        assert result.exit_code == 0
+        assert "--from TEXT" in result.output
+        assert "Source branch/commit to create worktree from" in result.output
+
+    def test_dynamic_branch_command_help_shows_from_option(self):
+        """Test that --from option appears in dynamic branch command help."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["test-branch", "--help"])
+
+        assert result.exit_code == 0
+        assert "--from TEXT" in result.output
+        assert "Source branch/commit to create worktree from" in result.output

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -6,6 +6,7 @@ from autowt.models import (
     BranchStatus,
     CleanupMode,
     ProcessInfo,
+    SwitchCommand,
     TerminalMode,
     WorktreeInfo,
 )
@@ -64,6 +65,33 @@ class TestProcessInfo:
         assert process.pid == 1234
         assert process.command == "python server.py"
         assert process.working_dir == working_dir
+
+
+class TestSwitchCommand:
+    """Tests for SwitchCommand model."""
+
+    def test_switch_command_creation(self):
+        """Test creating SwitchCommand instance."""
+        cmd = SwitchCommand(
+            branch="test-branch", terminal_mode=TerminalMode.TAB, from_branch="main"
+        )
+
+        assert cmd.branch == "test-branch"
+        assert cmd.terminal_mode == TerminalMode.TAB
+        assert cmd.from_branch == "main"
+
+    def test_switch_command_defaults(self):
+        """Test SwitchCommand default values."""
+        cmd = SwitchCommand(branch="test-branch")
+
+        assert cmd.branch == "test-branch"
+        assert cmd.terminal_mode is None
+        assert cmd.init_script is None
+        assert cmd.after_init is None
+        assert cmd.ignore_same_session is False
+        assert cmd.auto_confirm is False
+        assert cmd.debug is False
+        assert cmd.from_branch is None
 
 
 class TestEnums:


### PR DESCRIPTION
Adds a new `--from` flag to the `autowt switch` command that allows users to specify which branch, tag, or commit to use as the source when creating new worktrees.

## Usage

```bash
# Create worktree from specific branch
autowt switch new-feature --from main

# Create worktree from tag  
autowt switch hotfix --from v1.2.3

# Create worktree from commit hash
autowt switch experiment --from abc123

# Direct branch command with --from
autowt new-feature --from develop
```

The flag accepts any git revision and only applies when creating new worktrees. When switching to existing worktrees, the flag is ignored. The implementation is fully backward compatible.

🤖 Generated with [Claude Code](https://claude.ai/code)