### PR TITLE
Add --dir option to specify custom worktree directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   - Accepts any git revision: branch names, tags, commit hashes, `HEAD`, etc.
   - Available for both `autowt switch` and direct branch commands (`autowt my-branch --from main`)
   - Only used when creating new worktrees; ignored when switching to existing ones
+- Added `--dir` option to override worktree directory at creation time
+  - Specify custom directory path: `autowt switch branch --dir /tmp/my-worktree`
+  - Supports both absolute and relative paths
+  - Available for both `autowt switch` and direct branch commands
 
 ### Changed
 

--- a/docs/clireference.md
+++ b/docs/clireference.md
@@ -18,6 +18,7 @@ The `autowt <branch-name>` form is a convenient shortcut. Use the explicit `swit
 | `--after-init <script>` | Runs a command *after* the `init` script completes. Perfect for starting a dev server or an [AI agent](agents.md). |
 | `--ignore-same-session` | Forces `autowt` to create a new terminal, even if a session for that worktree already exists. |
 | `--from <branch>` | Source branch/commit to create worktree from. Accepts any git revision: branch names, tags, commit hashes, `HEAD`, etc. Only used when creating new worktrees. |
+| `--dir <path>` | Directory path for the new worktree. Overrides the configured directory pattern. Supports both absolute and relative paths. |
 | `--waiting` | Switch to first agent waiting for input. |
 | `--latest` | Switch to most recently active agent. |
 | `-y`, `--yes` | Automatically confirms all prompts, such as the prompt to switch to an existing terminal session. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,7 +52,7 @@ Defines how worktrees are created and managed.
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `directory_pattern` | string | `"../{repo_name}-worktrees/{branch}"` | The template for creating worktree directory paths. Can use variables `{repo_dir}` (full repo path), `{repo_name}` (repo directory name), `{repo_parent_dir}` (parent directory of repo), `{branch}` (branch name), and environment variables like `$HOME`. Examples: `"{repo_parent_dir}/worktrees/{branch}"`, `"$HOME/worktrees/{repo_name}/{branch}"`. <br> **ENV**: `AUTOWT_WORKTREE_DIRECTORY_PATTERN` |
+| `directory_pattern` | string | `"../{repo_name}-worktrees/{branch}"` | The template for creating worktree directory paths. Can use variables `{repo_dir}` (full repo path), `{repo_name}` (repo directory name), `{repo_parent_dir}` (parent directory of repo), `{branch}` (branch name), and environment variables like `$HOME`. Examples: `"{repo_parent_dir}/worktrees/{branch}"`, `"$HOME/worktrees/{repo_name}/{branch}"`. This can be overridden on a per-command basis using the `--dir` flag. <br> **ENV**: `AUTOWT_WORKTREE_DIRECTORY_PATTERN` <br> **CLI**: `--dir <path>` |
 | `max_worktrees` | integer | `null` | The maximum number of worktrees allowed per repository. Helps prevent excessive disk usage. <br> **ENV**: `AUTOWT_WORKTREE_MAX_WORKTREES` |
 | `auto_fetch` | boolean | `true` | If `true`, automatically fetches from the remote before creating new worktrees. <br> **ENV**: `AUTOWT_WORKTREE_AUTO_FETCH` <br> **CLI**: `--no-fetch` (to disable) |
 | `default_remote` | string | `"origin"` | The default remote to use when multiple remotes exist. <br> **ENV**: `AUTOWT_WORKTREE_DEFAULT_REMOTE` |

--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -112,6 +112,16 @@ autowt hotfix/urgent-bug --terminal=inplace
 autowt new-feature --terminal=inplace
 ```
 
+For special cases where you need the worktree in a specific location, you can override the default directory pattern with `--dir`:
+
+```bash
+# Place in a custom location
+autowt urgent-fix --dir /tmp/quick-fix
+
+# Use a relative path from current directory
+autowt feature-demo --dir ../demo-workspace
+```
+
 Run `autowt config` to configure the default terminal behavior for switching worktrees.
 
 ### Cleaning up

--- a/src/autowt/cli.py
+++ b/src/autowt/cli.py
@@ -212,6 +212,7 @@ class AutowtGroup(ClickAliasedGroup):
                 debug=kwargs.get("debug", False),
                 custom_script=kwargs.get("custom_script"),
                 from_branch=kwargs.get("from_branch"),
+                dir=kwargs.get("dir"),
             )
             checkout_branch(switch_cmd, services)
 
@@ -253,6 +254,10 @@ class AutowtGroup(ClickAliasedGroup):
                     ["--from"],
                     "from_branch",
                     help="Source branch/commit to create worktree from (any git rev: branch, tag, HEAD, etc.)",
+                ),
+                click.Option(
+                    ["--dir"],
+                    help="Directory path for the new worktree (overrides config pattern)",
                 ),
             ],
             help=f"Switch to or create a worktree for branch '{cmd_name}'",
@@ -513,6 +518,10 @@ def shellconfig(debug: bool, shell: str | None) -> None:
     "--custom-script",
     help="Custom script to run with arguments (e.g., 'bugfix 123')",
 )
+@click.option(
+    "--dir",
+    help="Directory path for the new worktree (overrides config pattern)",
+)
 def switch(
     branch: str | None,
     terminal: str | None,
@@ -525,6 +534,7 @@ def switch(
     from_branch: str | None,
     debug: bool,
     custom_script: str | None,
+    dir: str | None,
 ) -> None:
     """Switch to or create a worktree for the specified branch."""
     setup_logging(debug)
@@ -577,6 +587,7 @@ def switch(
         debug=debug,
         custom_script=custom_script,
         from_branch=from_branch,
+        dir=dir,
     )
     checkout_branch(switch_cmd, services)
 

--- a/src/autowt/models.py
+++ b/src/autowt/models.py
@@ -203,6 +203,7 @@ class SwitchCommand:
     debug: bool = False
     custom_script: str | None = None
     from_branch: str | None = None
+    dir: str | None = None
 
 
 @dataclass

--- a/tests/unit/test_worktree_path_generation.py
+++ b/tests/unit/test_worktree_path_generation.py
@@ -426,3 +426,46 @@ class TestWorktreePathGeneration:
         # Pattern: "/srv/git/worktrees/myapp/hotfix"
         expected_path = Path("/srv/git/worktrees/myapp/hotfix")
         assert result_path == expected_path
+
+    def test_custom_dir_absolute_path(self):
+        """Test that custom_dir with absolute path overrides config pattern."""
+        repo_path = Path("/home/user/Code/www/myprojectroot/base-repo")
+        branch = "test-branch"
+        custom_dir = "/tmp/my-custom-worktree"
+
+        # Create mock services (shouldn't be called since custom_dir is provided)
+        mock_services = Mock()
+
+        with patch("pathlib.Path.mkdir"):
+            result_path = _generate_worktree_path(
+                mock_services, repo_path, branch, custom_dir
+            )
+
+        # Should use custom directory directly
+        expected_path = Path("/tmp/my-custom-worktree")
+        assert result_path == expected_path
+        # Verify that config loading was not called since custom_dir was provided
+        mock_services.state.load_config.assert_not_called()
+
+    def test_custom_dir_relative_path(self):
+        """Test that custom_dir with relative path works correctly."""
+        repo_path = Path("/home/user/Code/www/myprojectroot/base-repo")
+        branch = "test-branch"
+        custom_dir = "my-worktree"
+
+        # Create mock services (shouldn't be called since custom_dir is provided)
+        mock_services = Mock()
+
+        with (
+            patch("pathlib.Path.mkdir"),
+            patch("os.getcwd", return_value="/current/working/directory"),
+        ):
+            result_path = _generate_worktree_path(
+                mock_services, repo_path, branch, custom_dir
+            )
+
+        # Should use custom directory relative to current working directory
+        expected_path = Path("/current/working/directory/my-worktree")
+        assert result_path == expected_path
+        # Verify that config loading was not called since custom_dir was provided
+        mock_services.state.load_config.assert_not_called()


### PR DESCRIPTION
Adds `--dir` option to `autowt switch` allowing users to override the configured directory pattern at creation time.

The option supports both absolute and relative paths, with relative paths resolved from the current working directory. This provides flexibility when the default directory pattern doesn't fit specific use cases.

Updated documentation includes practical examples in the CLI reference, configuration guide, and getting started guide. Merged latest changes from main including custom script documentation improvements.

🤖 Generated with [Claude Code](https://claude.ai/code)