### PR TITLE
Add command aliases and confirmation for dynamic branch commands

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -79,20 +79,6 @@ jobs:
           path: './site'
           retention-days: 30
 
-      - name: Post PR comment with artifact link
-        if: github.event_name == 'pull_request'
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          issue-number: ${{ github.event.number }}
-          body: |
-            📚 **Documentation Preview**
-
-            A preview of the documentation for this PR has been built successfully.
-
-            You can download the artifact with the built site files from the summary of this workflow run:
-            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-            *Note: You must be logged into GitHub to download the artifact.*
 
       - name: Deploy to GitHub Pages
         if: github.ref == 'refs/heads/main'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
     - Comprehensive documentation with team workflow examples
 - Two-character command aliases for improved usability
     - `ls` → `list`, `ll`
-    - `cleanup` → `cl`
+    - `cleanup` → `cl`, `clean`
     - `config` → `configure`, `settings`, `cfg`, `conf`
     - `shellconfig` → `shconf`
     - `switch` → `sw`, `checkout`, `co`, `goto`, `go`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@
 
 ### Added
 
+- `pre_create` lifecycle hook for worktree creation validation
+    - Runs before worktree creation begins in the parent directory
+    - Can abort worktree creation by exiting with non-zero status
+    - Perfect for branch naming validation, resource checks, and pre-flight validation
+    - Comprehensive documentation with team workflow examples
+- Two-character command aliases for improved usability
+    - `ls` → `list`, `ll`
+    - `cleanup` → `cl`
+    - `config` → `configure`, `settings`, `cfg`, `conf`
+    - `shellconfig` → `shconf`
+    - `switch` → `sw`, `checkout`, `co`, `goto`, `go`
+- Confirmation prompt for dynamic branch commands to prevent typos
+    - Prompts "Create a branch 'branch-name' and worktree? (Y/n)" for commands like `autowt swtch`
+    - Defaults to "yes" for quick confirmation
+    - Can be bypassed with `-y`/`--yes` flag
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
     - Comprehensive documentation with team workflow examples
 - Two-character command aliases for improved usability
     - `ls` → `list`, `ll`
-    - `cleanup` → `cl`, `clean`
+    - `cleanup` → `cl`, `clean`, `prune`
     - `config` → `configure`, `settings`, `cfg`, `conf`
     - `shellconfig` → `shconf`
     - `switch` → `sw`, `checkout`, `co`, `goto`, `go`

--- a/docs/clireference.md
+++ b/docs/clireference.md
@@ -41,7 +41,7 @@ The @ symbol indicates that there is an active terminal session for a worktree. 
 ```
 
 ### `autowt cleanup`
-*(Alias: `cl`)*
+*(Aliases: `cl`, `clean`)*
 
 Safely removes worktrees, their directories, and associated local git branches. By default, it launches an interactive TUI to let you select which worktrees to remove. For more on cleanup strategies, see the [Branch Management](branchmanagement.md) guide.
 

--- a/docs/clireference.md
+++ b/docs/clireference.md
@@ -41,7 +41,7 @@ The @ symbol indicates that there is an active terminal session for a worktree. 
 ```
 
 ### `autowt cleanup`
-*(Aliases: `cl`, `clean`)*
+*(Aliases: `cl`, `clean`, `prune`)*
 
 Safely removes worktrees, their directories, and associated local git branches. By default, it launches an interactive TUI to let you select which worktrees to remove. For more on cleanup strategies, see the [Branch Management](branchmanagement.md) guide.
 

--- a/docs/clireference.md
+++ b/docs/clireference.md
@@ -3,7 +3,7 @@
 This page provides a comprehensive reference for all `autowt` commands, their options, and usage patterns. For a hands-on introduction, check out the [Getting Started](gettingstarted.md) guide.
 
 ### `autowt <branch-name>`
-*(Alias: `autowt switch <branch-name>`)*
+*(Aliases: `autowt switch <branch-name>`, `autowt sw <branch-name>`, `autowt checkout <branch-name>`, `autowt co <branch-name>`, `autowt goto <branch-name>`, `autowt go <branch-name>`)*
 
 This is the primary and most convenient way to use `autowt`. It's a dynamic command that intelligently handles switching to an existing worktree or creating a new one. `autowt` automatically determines whether the branch exists locally or on the remote, or if it needs to be created from your repository's main branch.
 
@@ -25,7 +25,7 @@ The `autowt <branch-name>` form is a convenient shortcut. Use the explicit `swit
 | `-y`, `--yes` | Automatically confirms all prompts, such as the prompt to switch to an existing terminal session. |
 
 ### `autowt ls`
-*(Alias: `list`)*
+*(Aliases: `list`, `ll`)*
 
 Lists all worktrees for the current project, indicating the main worktree, your current location, and any active terminal sessions. Running `autowt` with no arguments is equivalent to `autowt ls`.
 
@@ -41,6 +41,7 @@ The @ symbol indicates that there is an active terminal session for a worktree. 
 ```
 
 ### `autowt cleanup`
+*(Alias: `cl`)*
 
 Safely removes worktrees, their directories, and associated local git branches. By default, it launches an interactive TUI to let you select which worktrees to remove. For more on cleanup strategies, see the [Branch Management](branchmanagement.md) guide.
 
@@ -54,7 +55,7 @@ Safely removes worktrees, their directories, and associated local git branches. 
 | `--kill` / `--no-kill` | Overrides the configured behavior for terminating processes running in a worktree's directory before removal. |
 
 ### `autowt config`
-*(Aliases: `configure`, `settings`)*
+*(Aliases: `configure`, `settings`, `cfg`, `conf`)*
 
 Opens an interactive TUI to configure global `autowt` settings, such as the default terminal mode. Learn more in the [Configuration](configuration.md) guide.
 
@@ -65,6 +66,7 @@ Opens an interactive TUI to configure global `autowt` settings, such as the defa
 | `--show` | Display current configuration values from all sources (global and project). Useful for debugging configuration issues. |
 
 ### `autowt shellconfig`
+*(Alias: `shconf`)*
 
 Displays a function you could choose to add to your shell config to cd to worktrees without needing autowt to control your terminal program.
 

--- a/src/autowt/cli.py
+++ b/src/autowt/cli.py
@@ -358,7 +358,8 @@ def ls(debug: bool) -> None:
 
 
 @main.command(
-    aliases=["cl", "clean"], context_settings={"help_option_names": ["-h", "--help"]}
+    aliases=["cl", "clean", "prune"],
+    context_settings={"help_option_names": ["-h", "--help"]},
 )
 @click.option(
     "--mode",

--- a/src/autowt/cli.py
+++ b/src/autowt/cli.py
@@ -357,7 +357,9 @@ def ls(debug: bool) -> None:
     list_worktrees(services, debug=debug)
 
 
-@main.command(aliases=["cl"], context_settings={"help_option_names": ["-h", "--help"]})
+@main.command(
+    aliases=["cl", "clean"], context_settings={"help_option_names": ["-h", "--help"]}
+)
 @click.option(
     "--mode",
     type=click.Choice(["all", "remoteless", "merged", "interactive"]),

--- a/src/autowt/cli.py
+++ b/src/autowt/cli.py
@@ -213,6 +213,7 @@ class AutowtGroup(ClickAliasedGroup):
                 custom_script=kwargs.get("custom_script"),
                 from_branch=kwargs.get("from_branch"),
                 dir=kwargs.get("dir"),
+                from_dynamic_command=True,
             )
             checkout_branch(switch_cmd, services)
 
@@ -345,7 +346,7 @@ def register_session_for_path(debug: bool) -> None:
 
 
 @main.command(
-    aliases=["list"], context_settings={"help_option_names": ["-h", "--help"]}
+    aliases=["list", "ll"], context_settings={"help_option_names": ["-h", "--help"]}
 )
 @click.option("--debug", is_flag=True, help="Enable debug logging")
 def ls(debug: bool) -> None:
@@ -356,7 +357,7 @@ def ls(debug: bool) -> None:
     list_worktrees(services, debug=debug)
 
 
-@main.command(context_settings={"help_option_names": ["-h", "--help"]})
+@main.command(aliases=["cl"], context_settings={"help_option_names": ["-h", "--help"]})
 @click.option(
     "--mode",
     type=click.Choice(["all", "remoteless", "merged", "interactive"]),
@@ -445,7 +446,7 @@ def cleanup(
 
 
 @main.command(
-    aliases=["configure", "settings"],
+    aliases=["configure", "settings", "cfg", "conf"],
     context_settings={"help_option_names": ["-h", "--help"]},
 )
 @click.option("--debug", is_flag=True, help="Enable debug logging")
@@ -462,7 +463,9 @@ def config(debug: bool, show: bool) -> None:
         configure_settings(services)
 
 
-@main.command(context_settings={"help_option_names": ["-h", "--help"]})
+@main.command(
+    aliases=["shconf"], context_settings={"help_option_names": ["-h", "--help"]}
+)
 @click.option("--debug", is_flag=True, help="Enable debug logging")
 @click.option(
     "--shell",
@@ -475,7 +478,10 @@ def shellconfig(debug: bool, shell: str | None) -> None:
     _show_shell_config(shell)
 
 
-@main.command(context_settings={"help_option_names": ["-h", "--help"]})
+@main.command(
+    aliases=["sw", "checkout", "co", "goto", "go"],
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
 @click.argument("branch", required=False)
 @click.option(
     "--terminal",
@@ -615,7 +621,10 @@ def agents(debug: bool) -> None:
             checkout_branch(switch_cmd, services)
 
 
-@main.command(context_settings={"help_option_names": ["-h", "--help"]})
+@main.command(
+    "hooks-install",
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
 @click.option(
     "--user", is_flag=True, help="Install hooks at user level (affects all projects)"
 )

--- a/src/autowt/commands/checkout.py
+++ b/src/autowt/commands/checkout.py
@@ -170,6 +170,14 @@ def checkout_branch(switch_cmd: SwitchCommand, services: Services) -> None:
 
     # Create new worktree
     try:
+        # If this is a dynamic command (not explicit 'switch'), prompt for confirmation
+        if switch_cmd.from_dynamic_command and not switch_cmd.auto_confirm:
+            if not confirm_default_yes(
+                f"Create a branch '{switch_cmd.branch}' and worktree?"
+            ):
+                print_info("Worktree creation cancelled.")
+                return
+
         _create_new_worktree(
             services,
             switch_cmd,

--- a/src/autowt/models.py
+++ b/src/autowt/models.py
@@ -231,6 +231,7 @@ class SwitchCommand:
     custom_script: str | None = None
     from_branch: str | None = None
     dir: str | None = None
+    from_dynamic_command: bool = False
 
 
 @dataclass

--- a/tests/integration/test_branch_switching_e2e.py
+++ b/tests/integration/test_branch_switching_e2e.py
@@ -13,7 +13,7 @@ class TestBranchSwitchingE2E:
         """Test creating a new worktree for a new branch."""
         # Change to the test repo directory
         with patch("os.getcwd", return_value=str(temp_git_repo)):
-            result = cli_runner.invoke(main, ["new-feature-branch"])
+            result = cli_runner.invoke(main, ["new-feature-branch", "-y"])
 
         assert result.exit_code == 0
 
@@ -36,7 +36,7 @@ class TestBranchSwitchingE2E:
 
         # Change to the test repo directory
         with patch("os.getcwd", return_value=str(temp_git_repo)):
-            result = cli_runner.invoke(main, ["feature/test-branch"])
+            result = cli_runner.invoke(main, ["feature/test-branch", "-y"])
 
         print(f"Test result exit_code: {result.exit_code}")
         print(f"Test result output: {repr(result.output)}")
@@ -51,7 +51,9 @@ class TestBranchSwitchingE2E:
         """Test branch switching with init script."""
         # Change to the test repo directory
         with patch("os.getcwd", return_value=str(temp_git_repo)):
-            result = cli_runner.invoke(main, ["script-branch", "--init", "npm install"])
+            result = cli_runner.invoke(
+                main, ["script-branch", "--init", "npm install", "-y"]
+            )
 
         assert result.exit_code == 0
 
@@ -66,7 +68,9 @@ class TestBranchSwitchingE2E:
         """Test that CLI terminal mode options are processed correctly."""
         # Change to the test repo directory
         with patch("os.getcwd", return_value=str(temp_git_repo)):
-            result = cli_runner.invoke(main, ["window-branch", "--terminal", "window"])
+            result = cli_runner.invoke(
+                main, ["window-branch", "--terminal", "window", "-y"]
+            )
 
         assert result.exit_code == 0
 
@@ -92,6 +96,7 @@ class TestBranchSwitchingE2E:
                     "echo 'Setting up'",
                     "--after-init",
                     "code .",
+                    "-y",
                 ],
             )
 

--- a/tests/integration/test_cli_options_e2e.py
+++ b/tests/integration/test_cli_options_e2e.py
@@ -15,7 +15,9 @@ class TestCLIOptionsE2E:
 
         for mode in terminal_modes:
             with patch("os.getcwd", return_value=str(temp_git_repo)):
-                result = cli_runner.invoke(main, ["test-branch", "--terminal", mode])
+                result = cli_runner.invoke(
+                    main, ["test-branch", "--terminal", mode, "-y"]
+                )
 
             assert result.exit_code == 0
 
@@ -27,7 +29,8 @@ class TestCLIOptionsE2E:
         """Test --init option processing."""
         with patch("os.getcwd", return_value=str(temp_git_repo)):
             result = cli_runner.invoke(
-                main, ["init-test-branch", "--init", "npm install && npm run build"]
+                main,
+                ["init-test-branch", "--init", "npm install && npm run build", "-y"],
             )
 
         assert result.exit_code == 0
@@ -45,6 +48,7 @@ class TestCLIOptionsE2E:
                     "after-init-branch",
                     "--after-init",
                     "code . && echo 'Ready to code!'",
+                    "-y",
                 ],
             )
 
@@ -65,6 +69,7 @@ class TestCLIOptionsE2E:
                     "echo 'Setting up environment'",
                     "--after-init",
                     "echo 'Opening editor'",
+                    "-y",
                 ],
             )
 
@@ -93,7 +98,7 @@ class TestCLIOptionsE2E:
         """Test --ignore-same-session option."""
         with patch("os.getcwd", return_value=str(temp_git_repo)):
             result = cli_runner.invoke(
-                main, ["ignore-session-branch", "--ignore-same-session"]
+                main, ["ignore-session-branch", "--ignore-same-session", "-y"]
             )
 
         assert result.exit_code == 0
@@ -104,7 +109,7 @@ class TestCLIOptionsE2E:
     def test_debug_option(self, temp_git_repo, force_echo_mode, cli_runner):
         """Test --debug option enables additional logging."""
         with patch("os.getcwd", return_value=str(temp_git_repo)):
-            result = cli_runner.invoke(main, ["debug-branch", "--debug"])
+            result = cli_runner.invoke(main, ["debug-branch", "--debug", "-y"])
 
         assert result.exit_code == 0
 
@@ -158,7 +163,12 @@ class TestCLIOptionsE2E:
         with patch("os.getcwd", return_value=str(temp_git_repo)):
             result = cli_runner.invoke(
                 main,
-                ["config-override-branch", "--init", "echo 'CLI overrides config'"],
+                [
+                    "config-override-branch",
+                    "--init",
+                    "echo 'CLI overrides config'",
+                    "-y",
+                ],
             )
 
         assert result.exit_code == 0

--- a/tests/unit/commands/test_checkout_confirmation.py
+++ b/tests/unit/commands/test_checkout_confirmation.py
@@ -1,0 +1,147 @@
+"""Tests for checkout command confirmation behavior."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from autowt.commands.checkout import checkout_branch
+from autowt.models import SwitchCommand, TerminalMode, WorktreeInfo
+
+
+class TestCheckoutConfirmation:
+    """Tests for confirmation behavior during checkout."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mock_services = MagicMock()
+        self.mock_services.git.find_repo_root.return_value = Path("/mock/repo")
+        self.mock_services.git.list_worktrees.return_value = []
+        self.mock_services.state.load_config.return_value = MagicMock()
+        self.mock_services.state.load_project_config.return_value = MagicMock()
+
+        # Mock project config to return None for session_init
+        project_config = MagicMock()
+        project_config.session_init = None
+        self.mock_services.state.load_project_config.return_value = project_config
+
+    @patch("autowt.commands.checkout.confirm_default_yes")
+    @patch("autowt.commands.checkout._create_new_worktree")
+    def test_dynamic_command_prompts_for_confirmation(
+        self, mock_create_worktree, mock_confirm
+    ):
+        """Test that dynamic branch commands prompt for confirmation before creating worktree."""
+        mock_confirm.return_value = True
+
+        switch_cmd = SwitchCommand(
+            branch="test-branch",
+            terminal_mode=TerminalMode.ECHO,
+            from_dynamic_command=True,
+            auto_confirm=False,
+        )
+
+        checkout_branch(switch_cmd, self.mock_services)
+
+        # Should prompt for confirmation
+        mock_confirm.assert_called_once_with(
+            "Create a branch 'test-branch' and worktree?"
+        )
+        # Should proceed with worktree creation after confirmation
+        mock_create_worktree.assert_called_once()
+
+    @patch("autowt.commands.checkout.confirm_default_yes")
+    @patch("autowt.commands.checkout._create_new_worktree")
+    @patch("autowt.commands.checkout.print_info")
+    def test_dynamic_command_cancels_when_user_declines(
+        self, mock_print_info, mock_create_worktree, mock_confirm
+    ):
+        """Test that dynamic branch commands cancel when user declines confirmation."""
+        mock_confirm.return_value = False
+
+        switch_cmd = SwitchCommand(
+            branch="test-branch",
+            terminal_mode=TerminalMode.ECHO,
+            from_dynamic_command=True,
+            auto_confirm=False,
+        )
+
+        checkout_branch(switch_cmd, self.mock_services)
+
+        # Should prompt for confirmation
+        mock_confirm.assert_called_once_with(
+            "Create a branch 'test-branch' and worktree?"
+        )
+        # Should not create worktree when declined
+        mock_create_worktree.assert_not_called()
+        # Should show cancellation message
+        mock_print_info.assert_called_with("Worktree creation cancelled.")
+
+    @patch("autowt.commands.checkout.confirm_default_yes")
+    @patch("autowt.commands.checkout._create_new_worktree")
+    def test_dynamic_command_with_auto_confirm_skips_prompt(
+        self, mock_create_worktree, mock_confirm
+    ):
+        """Test that dynamic commands with auto_confirm skip the confirmation prompt."""
+        switch_cmd = SwitchCommand(
+            branch="test-branch",
+            terminal_mode=TerminalMode.ECHO,
+            from_dynamic_command=True,
+            auto_confirm=True,
+        )
+
+        checkout_branch(switch_cmd, self.mock_services)
+
+        # Should not prompt when auto_confirm is True
+        mock_confirm.assert_not_called()
+        # Should proceed with worktree creation
+        mock_create_worktree.assert_called_once()
+
+    @patch("autowt.commands.checkout.confirm_default_yes")
+    @patch("autowt.commands.checkout._create_new_worktree")
+    def test_explicit_switch_command_does_not_prompt(
+        self, mock_create_worktree, mock_confirm
+    ):
+        """Test that explicit switch commands do not prompt for confirmation."""
+        switch_cmd = SwitchCommand(
+            branch="test-branch",
+            terminal_mode=TerminalMode.ECHO,
+            from_dynamic_command=False,  # Explicit switch command
+            auto_confirm=False,
+        )
+
+        checkout_branch(switch_cmd, self.mock_services)
+
+        # Should not prompt for explicit switch commands
+        mock_confirm.assert_not_called()
+        # Should proceed with worktree creation
+        mock_create_worktree.assert_called_once()
+
+    @patch("autowt.commands.checkout._create_new_worktree")
+    def test_existing_worktree_does_not_prompt(self, mock_create_worktree):
+        """Test that switching to existing worktree does not prompt."""
+        # Mock existing worktree
+        existing_worktree = WorktreeInfo(
+            branch="test-branch",
+            path=Path("/mock/repo-worktrees/test-branch"),
+            is_current=False,
+            is_primary=False,
+        )
+        self.mock_services.git.list_worktrees.return_value = [existing_worktree]
+
+        # Mock successful terminal switch
+        self.mock_services.terminal.switch_to_worktree.return_value = True
+
+        switch_cmd = SwitchCommand(
+            branch="test-branch",
+            terminal_mode=TerminalMode.ECHO,
+            from_dynamic_command=True,
+            auto_confirm=False,
+        )
+
+        with patch("autowt.commands.checkout.confirm_default_yes") as mock_confirm:
+            checkout_branch(switch_cmd, self.mock_services)
+
+            # Should not prompt when worktree already exists
+            mock_confirm.assert_not_called()
+            # Should not create new worktree
+            mock_create_worktree.assert_not_called()
+            # Should switch to existing worktree
+            self.mock_services.terminal.switch_to_worktree.assert_called_once()


### PR DESCRIPTION
## Summary

- Add confirmation prompt for dynamic branch commands to prevent typos when using commands like `autowt swtch`
- Add two-character command aliases for improved usability:
  - `ls` → `list`, `ll`
  - `cleanup` → `cl`, `clean`, `prune`  
  - `config` → `configure`, `settings`, `cfg`, `conf`
  - `shellconfig` → `shconf`
  - `switch` → `sw`, `checkout`, `co`, `goto`, `go`
- Remove PR comment step from docs workflow

## Test plan

- [x] All existing tests pass
- [x] Added comprehensive unit tests for confirmation functionality
- [x] Updated integration tests to handle confirmation prompts
- [x] Verified aliases work correctly in CLI

🤖 Generated with [Claude Code](https://claude.ai/code)