### PR TITLE
Add interactive switch TUI with auto-selection and sorting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,1 +1,7 @@
 <!-- CHANGELOG_INSERT -->
+
+## Unreleased
+
+### Added
+
+- Interactive switch TUI: Running `autowt switch` with no arguments opens an interactive interface that shows existing worktrees (sorted by creation time), branches without worktrees, and allows creating new branches inline. The most recently created worktree is auto-selected.

--- a/docs/clireference.md
+++ b/docs/clireference.md
@@ -2,10 +2,15 @@
 
 This page provides a comprehensive reference for all `autowt` commands, their options, and usage patterns. For a hands-on introduction, check out the [Getting Started](gettingstarted.md) guide.
 
-### `autowt <branch-name>`
+### `autowt <branch-name>` / `autowt switch`
 *(Aliases: `autowt switch <branch-name>`, `autowt sw <branch-name>`, `autowt checkout <branch-name>`, `autowt co <branch-name>`, `autowt goto <branch-name>`, `autowt go <branch-name>`)*
 
-This is the primary and most convenient way to use `autowt`. It's a dynamic command that intelligently handles switching to an existing worktree or creating a new one. `autowt` automatically determines whether the branch exists locally or on the remote, or if it needs to be created from your repository's main branch.
+This is the primary and most convenient way to use `autowt`. It intelligently handles switching to an existing worktree or creating a new one. `autowt` automatically determines whether the branch exists locally or on the remote, or if it needs to be created from your repository's main branch.
+
+**Interactive Mode**: Running `autowt switch` with no arguments opens an interactive TUI that shows:
+- Existing worktrees you can switch to
+- Branches without worktrees (creates a new worktree when selected)
+- Option to create a new branch interactively
 
 The `autowt <branch-name>` form is a convenient shortcut. Use the explicit `switch` command if your branch name conflicts with another `autowt` command (e.g., `autowt switch cleanup`).
 

--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -86,6 +86,13 @@ The output will look something like this, with an arrow `→` indicating your cu
 
     `autowt` with no arguments is an alias for `autowt ls`.
 
+!!! tip "Interactive switching"
+
+    You can also use `autowt switch` with no arguments to open an interactive TUI that lets you:
+    - Select from existing worktrees to switch to
+    - Choose branches without worktrees (automatically creates a new worktree)
+    - Create a new branch by entering its name
+
 !!! tip "Additional worktree setup"
 
     If you want dependencies to be installed automatically when creating new worktrees, or need to copy over git-ignored files like `.env` from the main worktree, you can learn how to configure lifecycle hooks in the [Lifecycle Hooks guide](lifecyclehooks.md).

--- a/src/autowt/cli.py
+++ b/src/autowt/cli.py
@@ -24,13 +24,6 @@ from autowt.commands.hooks import (
     show_installed_hooks,
 )
 from autowt.commands.ls import list_worktrees
-
-try:
-    from autowt.tui.switch import run_switch_tui
-
-    HAS_SWITCH_TUI = True
-except ImportError:
-    HAS_SWITCH_TUI = False
 from autowt.config import get_config
 from autowt.global_config import options
 from autowt.models import (
@@ -41,6 +34,7 @@ from autowt.models import (
     TerminalMode,
 )
 from autowt.services.version_check import VersionCheckService
+from autowt.tui.switch import run_switch_tui
 from autowt.utils import run_command_quiet_on_failure, setup_command_logging
 
 
@@ -206,10 +200,6 @@ def _show_shell_config(shell_override: str | None = None) -> None:
 
 def _run_interactive_switch(services) -> tuple[str | None, bool]:
     """Run interactive switch TUI and return selected branch and if it's new."""
-    if not HAS_SWITCH_TUI:
-        print("Interactive switch not available (Textual dependency missing)")
-        return None, False
-
     # Find git repository
     repo_path = services.git.find_repo_root()
     if not repo_path:

--- a/src/autowt/cli.py
+++ b/src/autowt/cli.py
@@ -97,6 +97,9 @@ def check_for_version_updates(services: Services) -> None:
                 err=True,
             )
             click.echo(f"   Run: {method.command}", err=True)
+            click.echo(
+                "   Release notes: https://github.com/irskep/autowt/releases", err=True
+            )
             click.echo("", err=True)
             return
 
@@ -110,6 +113,8 @@ def check_for_version_updates(services: Services) -> None:
             )
             if version_info.install_command:
                 click.echo(f"   Run: {version_info.install_command}", err=True)
+            if version_info.changelog_url:
+                click.echo(f"   Release notes: {version_info.changelog_url}", err=True)
             click.echo("", err=True)  # Add blank line for spacing
     except Exception:
         # Silently fail - version checking should never break the main command

--- a/src/autowt/services/version_check.py
+++ b/src/autowt/services/version_check.py
@@ -19,6 +19,7 @@ class VersionInfo(NamedTuple):
     latest: str
     update_available: bool
     install_command: str | None
+    changelog_url: str | None
 
 
 class InstallationMethod(NamedTuple):
@@ -180,11 +181,17 @@ class VersionCheckService:
             method = self._detect_installation_method()
             install_command = method.command
 
+        # Generate changelog URL (GitHub releases page)
+        changelog_url = (
+            "https://github.com/irskep/autowt/releases" if update_available else None
+        )
+
         return VersionInfo(
             current=current,
             latest=latest,
             update_available=update_available,
             install_command=install_command,
+            changelog_url=changelog_url,
         )
 
     def get_cached_version_info(self) -> dict | None:
@@ -207,5 +214,6 @@ class VersionCheckService:
         if update_available:
             method = self._detect_installation_method()
             result["install_command"] = method.command
+            result["changelog_url"] = "https://github.com/irskep/autowt/releases"
 
         return result

--- a/src/autowt/tui/switch.css
+++ b/src/autowt/tui/switch.css
@@ -1,0 +1,113 @@
+/* CSS for the switch TUI */
+
+#main {
+    height: 100%;
+    background: $surface;
+}
+
+#header-section {
+    height: auto;
+    dock: top;
+    padding: 1;
+    background: $surface;
+}
+
+#instructions {
+    color: $text;
+    text-style: bold;
+    margin-bottom: 1;
+}
+
+#status-bar {
+    color: $text-muted;
+    margin-bottom: 1;
+}
+
+#branch-list {
+    height: 1fr;
+    scrollbar-background: $surface;
+    scrollbar-color: $primary;
+    scrollbar-color-hover: $primary-lighten-1;
+    scrollbar-color-active: $primary-lighten-2;
+}
+
+.section-header {
+    color: $accent;
+    text-style: bold;
+    padding: 1 0;
+    background: $surface-lighten-1;
+}
+
+.branch-row {
+    height: 2;
+    align: left middle;
+    background: $surface;
+}
+
+.branch-row:hover {
+    background: $surface-lighten-1;
+}
+
+.branch-info {
+    width: 1fr;
+    color: $text;
+    padding: 0 1;
+}
+
+.status-info {
+    width: auto;
+    min-width: 15;
+    color: $text-muted;
+    text-align: center;
+    padding: 0 1;
+}
+
+.selection-indicator {
+    width: auto;
+    min-width: 5;
+    color: $text-muted;
+    text-align: center;
+    padding: 0 1;
+}
+
+.selection-indicator:hover {
+    color: $primary;
+    text-style: bold;
+}
+
+#new-branch-input {
+    height: 3;
+    margin: 1;
+    border: solid $primary;
+}
+
+#button-row {
+    height: auto;
+    dock: bottom;
+    align: center bottom;
+    padding: 1;
+}
+
+#confirm {
+    margin-right: 2;
+}
+
+#cancel {
+    margin-left: 2;
+}
+
+#empty {
+    height: 100%;
+    content-align: center middle;
+    color: $text-muted;
+}
+
+/* Cursor styling */
+ListView > .option-list--option-highlighted {
+    background: $primary-lighten-3;
+}
+
+ListView > .option-list--option-highlighted .branch-info {
+    color: $text;
+    text-style: bold;
+}

--- a/src/autowt/tui/switch.py
+++ b/src/autowt/tui/switch.py
@@ -1,0 +1,466 @@
+"""Textual TUI for interactive branch switching."""
+
+from pathlib import Path
+
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import Container, Horizontal, Vertical
+from textual.widgets import Button, Footer, Header, Input, ListItem, ListView, Static
+
+from autowt.models import WorktreeInfo
+
+
+class ClickableStatic(Static):
+    """A Static widget that can handle clicks."""
+
+    def __init__(self, *args, on_click_callback=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.on_click_callback = on_click_callback
+
+    def on_click(self) -> None:
+        """Handle click events on this widget."""
+        if self.on_click_callback:
+            self.on_click_callback()
+
+
+class SwitchTUI(App):
+    """Interactive switch interface using Textual."""
+
+    TITLE = "Autowt - Interactive Switch"
+    CSS_PATH = "switch.css"
+    BINDINGS = [
+        Binding("q,escape", "quit", "Quit"),
+        Binding("n", "new_branch", "New"),
+        Binding("space", "toggle_selection", "Select"),
+        Binding("j", "cursor_down", "Down"),
+        Binding("k", "cursor_up", "Up"),
+        Binding("enter", "confirm", "Switch"),
+    ]
+
+    def __init__(self, worktrees: list[WorktreeInfo], all_branches: list[str]):
+        super().__init__()
+
+        # Sort worktrees by creation time (latest first)
+        self.worktrees = self._sort_worktrees_by_creation_time(worktrees)
+        self.all_branches = all_branches
+        self.selected_index = None
+        self.selected_branch = None
+        self.is_new_branch = False
+        self.list_view = None
+        self.new_branch_input = None
+
+        # Find branches without worktrees
+        worktree_branches = {wt.branch for wt in self.worktrees}
+        self.branches_without_worktrees = [
+            branch for branch in all_branches if branch not in worktree_branches
+        ]
+
+    def compose(self) -> ComposeResult:
+        """Create the TUI layout."""
+        yield Header()
+
+        with Container(id="main"):
+            with Vertical(id="header-section"):
+                yield Static(
+                    "Select a branch to switch to (Enter=switch, n=new branch):",
+                    id="instructions",
+                )
+                yield Static(
+                    f"Found {len(self.worktrees)} worktrees, {len(self.branches_without_worktrees)} branches without worktrees",
+                    id="status-bar",
+                )
+
+            # Create list items for worktrees and branches without worktrees
+            list_items = []
+
+            # Add existing worktrees
+            if self.worktrees:
+                header_item = ListItem(
+                    Static("[bold]Existing Worktrees[/]", classes="section-header")
+                )
+                header_item.disabled = True
+                list_items.append(header_item)
+                for i, worktree in enumerate(self.worktrees):
+                    list_items.append(self._create_worktree_item(i, worktree))
+
+            # Add branches without worktrees
+            if self.branches_without_worktrees:
+                header_item = ListItem(
+                    Static("[bold]Branches (no worktree)[/]", classes="section-header")
+                )
+                header_item.disabled = True
+                list_items.append(header_item)
+                for i, branch in enumerate(self.branches_without_worktrees):
+                    list_items.append(
+                        self._create_branch_item(len(self.worktrees) + i, branch)
+                    )
+
+            # Add "New Branch" option
+            actions_header = ListItem(
+                Static("[bold]Actions[/]", classes="section-header")
+            )
+            actions_header.disabled = True
+            list_items.append(actions_header)
+            new_branch_item = self._create_new_branch_item(
+                len(self.worktrees) + len(self.branches_without_worktrees)
+            )
+            list_items.append(new_branch_item)
+
+            if not list_items:
+                yield Static("No worktrees or branches found.", id="empty")
+            else:
+                self.list_view = ListView(*list_items, id="branch-list")
+                yield self.list_view
+
+            # New branch input (initially hidden)
+            self.new_branch_input = Input(
+                placeholder="Enter new branch name...",
+                id="new-branch-input",
+            )
+            self.new_branch_input.display = False
+            yield self.new_branch_input
+
+            with Horizontal(id="button-row"):
+                yield Button("Switch", id="confirm", variant="primary")
+                yield Button("Cancel", id="cancel", variant="error")
+
+        yield Footer()
+
+    def _sort_worktrees_by_creation_time(
+        self, worktrees: list[WorktreeInfo]
+    ) -> list[WorktreeInfo]:
+        """Sort worktrees by creation time (latest first), with primary worktree last."""
+
+        def get_creation_time(worktree: WorktreeInfo) -> float:
+            try:
+                # Get directory creation time (stat.st_ctime on most systems)
+                stat = worktree.path.stat()
+                return stat.st_ctime
+            except (OSError, AttributeError):
+                # Fallback for cases where path doesn't exist or stat fails
+                return 0.0
+
+        # Separate primary worktree from others
+        primary_worktrees = [wt for wt in worktrees if wt.is_primary]
+        regular_worktrees = [wt for wt in worktrees if not wt.is_primary]
+
+        # Sort regular worktrees by creation time (newest first)
+        regular_worktrees.sort(key=get_creation_time, reverse=True)
+
+        # Return regular worktrees first, then primary
+        return regular_worktrees + primary_worktrees
+
+    def _create_worktree_item(self, index: int, worktree: WorktreeInfo) -> ListItem:
+        """Create a list item for an existing worktree."""
+        # Format path for display
+        relative_path = self._format_path_for_display(worktree.path)
+
+        status_text = "[green]ready[/]"
+        if worktree.is_current:
+            status_text = "[blue]current[/]"
+
+        def handle_selection_click():
+            self.selected_index = index
+            self.selected_branch = worktree.branch
+            self.is_new_branch = False
+            if self.list_view:
+                self.list_view.index = index + 1  # +1 for section header
+            self._update_selection_display()
+
+        selection_widget = ClickableStatic(
+            "[dim][ ][/]",
+            id=f"sel-{index}",
+            classes="selection-indicator",
+            on_click_callback=handle_selection_click,
+        )
+
+        content = Horizontal(
+            Static(f"{worktree.branch}\n{relative_path}", classes="branch-info"),
+            Static(status_text, classes="status-info"),
+            selection_widget,
+            classes="branch-row",
+        )
+
+        return ListItem(content, id=f"worktree-{index}")
+
+    def _create_branch_item(self, index: int, branch: str) -> ListItem:
+        """Create a list item for a branch without a worktree."""
+
+        def handle_selection_click():
+            self.selected_index = index
+            self.selected_branch = branch
+            self.is_new_branch = False
+            if self.list_view:
+                # Calculate actual list position (account for section headers)
+                list_pos = 1 + len(self.worktrees) + 1 + (index - len(self.worktrees))
+                self.list_view.index = list_pos
+            self._update_selection_display()
+
+        selection_widget = ClickableStatic(
+            "[dim][ ][/]",
+            id=f"sel-{index}",
+            classes="selection-indicator",
+            on_click_callback=handle_selection_click,
+        )
+
+        content = Horizontal(
+            Static(f"{branch}\nNo worktree", classes="branch-info"),
+            Static("[yellow]needs worktree[/]", classes="status-info"),
+            selection_widget,
+            classes="branch-row",
+        )
+
+        return ListItem(content, id=f"branch-{index}")
+
+    def _create_new_branch_item(self, index: int) -> ListItem:
+        """Create a list item for creating a new branch."""
+
+        def handle_selection_click():
+            self.action_new_branch()
+
+        selection_widget = ClickableStatic(
+            "[bold green]+[/]",
+            id=f"sel-{index}",
+            classes="selection-indicator",
+            on_click_callback=handle_selection_click,
+        )
+
+        content = Horizontal(
+            Static("Create new branch\nEnter branch name", classes="branch-info"),
+            Static("[cyan]new[/]", classes="status-info"),
+            selection_widget,
+            classes="branch-row",
+        )
+
+        return ListItem(content, id=f"new-{index}")
+
+    def on_mount(self) -> None:
+        """Initialize after mounting."""
+        # Auto-select first worktree (most recently created) if available
+        if self.worktrees:
+            self.selected_index = 0
+            self.selected_branch = self.worktrees[0].branch
+            self.is_new_branch = False
+            self._update_selection_display()
+
+            # Set ListView cursor to the first worktree item
+            # Account for the "Existing Worktrees" section header
+            if self.list_view:
+                self.list_view.index = 1  # Skip section header
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle button presses."""
+        if event.button.id == "confirm":
+            self.action_confirm()
+        elif event.button.id == "cancel":
+            self.action_quit()
+
+    def action_toggle_selection(self) -> None:
+        """Toggle selection of current row."""
+        if not self.list_view:
+            return
+
+        cursor_row = self.list_view.index
+        self._handle_cursor_selection(cursor_row)
+
+    def action_new_branch(self) -> None:
+        """Show new branch input."""
+        if self.new_branch_input:
+            self.new_branch_input.display = True
+            self.new_branch_input.focus()
+            self.is_new_branch = True
+            self.selected_branch = None
+
+    def action_cursor_down(self) -> None:
+        """Move cursor down."""
+        if self.list_view:
+            self.list_view.action_cursor_down()
+
+    def action_cursor_up(self) -> None:
+        """Move cursor up."""
+        if self.list_view:
+            self.list_view.action_cursor_up()
+
+    def on_key(self, event) -> None:
+        """Handle key presses."""
+        if event.key == "enter":
+            # If the input field has focus, let it handle the enter key
+            if self.new_branch_input and self.new_branch_input.has_focus:
+                return  # Let the input field handle this
+
+            # If on the "new branch" option, show input; otherwise confirm
+            if self.list_view:
+                cursor_row = self.list_view.index
+                # Check if cursor is on "new branch" option
+                total_items = (
+                    (1 + len(self.worktrees) if self.worktrees else 0)
+                    + (
+                        1 + len(self.branches_without_worktrees)
+                        if self.branches_without_worktrees
+                        else 0
+                    )
+                    + 1
+                    + 1  # Actions header + new branch item
+                )
+                if cursor_row == total_items - 1:  # Last item is "new branch"
+                    self.action_new_branch()
+                else:
+                    # Update selection based on cursor position first
+                    self._handle_cursor_selection(cursor_row)
+                    self.action_confirm()
+            else:
+                self.action_confirm()
+            event.prevent_default()
+        elif event.key == "n":
+            # Don't interfere if input field has focus
+            if self.new_branch_input and self.new_branch_input.has_focus:
+                return
+            self.action_new_branch()
+            event.prevent_default()
+        elif event.key == " ":  # Space key
+            # Don't interfere if input field has focus
+            if self.new_branch_input and self.new_branch_input.has_focus:
+                return
+            if self.list_view:
+                self._handle_cursor_selection(self.list_view.index)
+            event.prevent_default()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Handle input submission for new branch name."""
+        if event.input.id == "new-branch-input":
+            branch_name = event.input.value.strip()
+            if branch_name:
+                self.selected_branch = branch_name
+                self.is_new_branch = True
+                self.action_confirm()
+            else:
+                # Hide input and go back to list
+                self.new_branch_input.display = False
+                self.is_new_branch = False
+                if self.list_view:
+                    self.list_view.focus()
+
+    def _handle_list_selection(self, index: int) -> None:
+        """Handle selection based on list index."""
+        if index < len(self.worktrees):
+            # Selecting a worktree
+            self.selected_index = index
+            self.selected_branch = self.worktrees[index].branch
+            self.is_new_branch = False
+        elif index < len(self.worktrees) + len(self.branches_without_worktrees):
+            # Selecting a branch without worktree
+            branch_index = index - len(self.worktrees)
+            self.selected_index = index
+            self.selected_branch = self.branches_without_worktrees[branch_index]
+            self.is_new_branch = False
+        else:
+            # Selecting "new branch" option
+            self.action_new_branch()
+            return
+
+        self._update_selection_display()
+
+    def _format_path_for_display(self, path) -> str:
+        """Format a path for compact display."""
+        try:
+            # Try to make it relative to current working directory
+            current_dir = Path.cwd()
+            relative_path = path.relative_to(current_dir)
+            return str(relative_path)
+        except ValueError:
+            # Try to make it relative to home directory
+            try:
+                home_dir = Path.home()
+                relative_path = path.relative_to(home_dir)
+                return f"~/{relative_path}"
+            except ValueError:
+                # Fall back to absolute path
+                return str(path)
+
+    def _update_selection_display(self) -> None:
+        """Update selection indicators."""
+        # Clear all selections first
+        for i in range(len(self.worktrees) + len(self.branches_without_worktrees) + 1):
+            try:
+                selection_widget = self.query_one(f"#sel-{i}", Static)
+                if i == self.selected_index:
+                    selection_widget.update("[bold green][\u2713][/]")
+                else:
+                    selection_widget.update("[dim][ ][/]")
+            except Exception:
+                # Ignore errors updating selection indicators
+                pass
+
+    def action_confirm(self) -> None:
+        """Confirm selection and exit."""
+        if (
+            self.is_new_branch
+            and self.new_branch_input
+            and self.new_branch_input.value.strip()
+        ):
+            self.selected_branch = self.new_branch_input.value.strip()
+
+        if self.selected_branch:
+            self.exit()
+        else:
+            # No selection made
+            self.action_quit()
+
+    def action_quit(self) -> None:
+        """Cancel and exit without selection."""
+        self.selected_branch = None
+        self.is_new_branch = False
+        self.exit()
+
+    def _handle_cursor_selection(self, cursor_row: int) -> None:
+        """Handle selection based on ListView cursor position, accounting for section headers."""
+        # Calculate which item the cursor is on, accounting for section headers
+        # Structure: [Existing Worktrees header, worktrees..., Branches header, branches..., Actions header, new branch]
+
+        current_row = 0
+
+        # Skip "Existing Worktrees" header if present
+        if self.worktrees:
+            current_row += 1  # Section header
+            if cursor_row < current_row + len(self.worktrees):
+                # Cursor is on a worktree
+                item_index = cursor_row - current_row
+                self.selected_index = item_index
+                self.selected_branch = self.worktrees[item_index].branch
+                self.is_new_branch = False
+                self._update_selection_display()
+                return
+            current_row += len(self.worktrees)
+
+        # Skip "Branches (no worktree)" header if present
+        if self.branches_without_worktrees:
+            current_row += 1  # Section header
+            if cursor_row < current_row + len(self.branches_without_worktrees):
+                # Cursor is on a branch without worktree
+                item_index = cursor_row - current_row
+                branch_index = item_index
+                self.selected_index = len(self.worktrees) + branch_index
+                self.selected_branch = self.branches_without_worktrees[branch_index]
+                self.is_new_branch = False
+                self._update_selection_display()
+                return
+            current_row += len(self.branches_without_worktrees)
+
+        # Skip "Actions" header
+        current_row += 1  # Section header
+        if cursor_row >= current_row:
+            # Cursor is on "new branch" option
+            self.action_new_branch()
+
+
+def run_switch_tui(
+    worktrees: list[WorktreeInfo], all_branches: list[str]
+) -> tuple[str | None, bool]:
+    """Run the switch TUI and return selected branch and whether it's a new branch.
+
+    Returns:
+        tuple: (selected_branch, is_new_branch) or (None, False) if cancelled
+    """
+    app = SwitchTUI(worktrees, all_branches)
+    app.run()
+    return app.selected_branch, app.is_new_branch

--- a/tests/unit/commands/test_agent_switching.py
+++ b/tests/unit/commands/test_agent_switching.py
@@ -216,22 +216,24 @@ class TestAgentSwitching:
         # Test branch + waiting
         result = runner.invoke(main, ["switch", "my-branch", "--waiting"])
         assert result.exit_code != 0
-        assert "Must specify exactly one of" in result.output
+        assert "Must specify at most one of" in result.output
 
         # Test branch + latest
         result = runner.invoke(main, ["switch", "my-branch", "--latest"])
         assert result.exit_code != 0
-        assert "Must specify exactly one of" in result.output
+        assert "Must specify at most one of" in result.output
 
         # Test waiting + latest
         result = runner.invoke(main, ["switch", "--waiting", "--latest"])
         assert result.exit_code != 0
-        assert "Must specify exactly one of" in result.output
+        assert "Must specify at most one of" in result.output
 
-        # Test no options
-        result = runner.invoke(main, ["switch"])
-        assert result.exit_code != 0
-        assert "Must specify exactly one of" in result.output
+        # Test no options (should attempt interactive mode)
+        with patch("autowt.cli._run_interactive_switch") as mock_interactive:
+            mock_interactive.return_value = (None, False)  # User cancelled
+            result = runner.invoke(main, ["switch"])
+            # Should exit cleanly when user cancels
+            assert result.exit_code == 0
 
     def test_switch_help_shows_all_options(self):
         """Test that switch help shows all available options."""


### PR DESCRIPTION
Running `autowt switch` with no arguments now opens an interactive TUI that displays existing worktrees (sorted by creation time with newest first), branches without worktrees, and allows creating new branches. The most recently created worktree is auto-selected for quick switching.

Section headers are non-focusable and keyboard navigation works smoothly. Users can navigate with j/k, select with space or enter, and create new branches by pressing 'n' or selecting the "Create new branch" option.

🤖 Generated with [Claude Code](https://claude.ai/code)