### PR TITLE
Add remote branch detection with user confirmation prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 ### Added
 
+- Remote branch detection and confirmation prompts when creating worktrees
+  - When attempting to create a worktree for a branch that doesn't exist locally, autowt now checks if it exists on remote
+  - Automatically fetches the specific branch from origin if available
+  - Prompts user to confirm creating a local worktree that tracks the remote branch
+  - Can be bypassed with `-y`/`--yes` flag for automated workflows
+  - Only applies when no explicit `--from` branch is specified
+
 ### Changed
 
 ### Fixed

--- a/src/autowt/commands/checkout.py
+++ b/src/autowt/commands/checkout.py
@@ -204,6 +204,22 @@ def _create_new_worktree(
     if not services.git.fetch_branches(repo_path):
         print_error("Warning: Failed to fetch latest branches")
 
+    # Check if branch exists on remote and prompt user if needed
+    if not switch_cmd.from_branch:  # Only check remote if no explicit source branch
+        remote_exists, remote_name = (
+            services.git.branch_resolver.check_remote_branch_availability(
+                repo_path, switch_cmd.branch
+            )
+        )
+
+        if remote_exists and not switch_cmd.auto_confirm:
+            if not confirm_default_yes(
+                f"Branch '{switch_cmd.branch}' exists on remote '{remote_name}'. "
+                f"Create a local worktree tracking the remote branch?"
+            ):
+                print_info("Worktree creation cancelled.")
+                return
+
     # Generate worktree path with sanitized branch name
     worktree_path = _generate_worktree_path(
         services, repo_path, switch_cmd.branch, switch_cmd.dir

--- a/tests/fixtures/service_builders.py
+++ b/tests/fixtures/service_builders.py
@@ -97,6 +97,19 @@ class MockStateService:
         self.app_state["experimental_terminal_warning_shown"] = True
 
 
+class MockBranchResolver:
+    """Mock branch resolver for testing."""
+
+    def __init__(self):
+        self.remote_branch_availability = (False, None)
+
+    def check_remote_branch_availability(
+        self, repo_path: Path, branch: str
+    ) -> tuple[bool, str | None]:
+        """Mock remote branch availability check."""
+        return self.remote_branch_availability
+
+
 class MockGitService:
     """Mock git service for testing."""
 
@@ -109,6 +122,7 @@ class MockGitService:
         self.create_success = True
         self.remove_success = True
         self.install_hooks_success = True
+        self.branch_resolver = MockBranchResolver()
 
         # Track method calls
         self.fetch_called = False

--- a/tests/unit/services/test_git_service.py
+++ b/tests/unit/services/test_git_service.py
@@ -238,3 +238,145 @@ class TestGitServiceQuietFailure:
                 timeout=10,
                 description="Check if origin/master exists",
             )
+
+
+class TestBranchResolver:
+    """Tests for BranchResolver remote branch detection."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.git_service = GitService()
+        self.repo_path = Path("/mock/repo")
+
+    def test_check_remote_branch_availability_when_local_exists(self):
+        """Test that check_remote_branch_availability returns False when branch exists locally."""
+        with patch.object(
+            self.git_service.branch_resolver,
+            "_branch_exists_locally",
+            return_value=True,
+        ):
+            result = self.git_service.branch_resolver.check_remote_branch_availability(
+                self.repo_path, "main"
+            )
+            assert result == (False, None)
+
+    def test_check_remote_branch_availability_fetches_and_finds_remote(self):
+        """Test that check_remote_branch_availability fetches branch and finds it on remote."""
+        with (
+            patch.object(
+                self.git_service.branch_resolver,
+                "_branch_exists_locally",
+                return_value=False,
+            ),
+            patch.object(
+                self.git_service.branch_resolver,
+                "_try_fetch_specific_branch",
+                return_value=True,
+            ),
+            patch.object(
+                self.git_service.branch_resolver,
+                "_branch_exists_remotely",
+                return_value=True,
+            ),
+        ):
+            result = self.git_service.branch_resolver.check_remote_branch_availability(
+                self.repo_path, "feature-branch"
+            )
+            assert result == (True, "origin")
+
+    def test_check_remote_branch_availability_fetch_fails(self):
+        """Test that check_remote_branch_availability returns False when fetch fails."""
+        with (
+            patch.object(
+                self.git_service.branch_resolver,
+                "_branch_exists_locally",
+                return_value=False,
+            ),
+            patch.object(
+                self.git_service.branch_resolver,
+                "_try_fetch_specific_branch",
+                return_value=False,
+            ),
+        ):
+            result = self.git_service.branch_resolver.check_remote_branch_availability(
+                self.repo_path, "nonexistent-branch"
+            )
+            assert result == (False, None)
+
+    def test_check_remote_branch_availability_fetch_succeeds_but_no_remote_branch(self):
+        """Test that check_remote_branch_availability returns False when fetch succeeds but branch not found remotely."""
+        with (
+            patch.object(
+                self.git_service.branch_resolver,
+                "_branch_exists_locally",
+                return_value=False,
+            ),
+            patch.object(
+                self.git_service.branch_resolver,
+                "_try_fetch_specific_branch",
+                return_value=True,
+            ),
+            patch.object(
+                self.git_service.branch_resolver,
+                "_branch_exists_remotely",
+                return_value=False,
+            ),
+        ):
+            result = self.git_service.branch_resolver.check_remote_branch_availability(
+                self.repo_path, "feature-branch"
+            )
+            assert result == (False, None)
+
+    def test_try_fetch_specific_branch_succeeds(self):
+        """Test that _try_fetch_specific_branch returns True when git fetch succeeds."""
+        with patch("autowt.services.git.run_command_quiet_on_failure") as mock_run:
+            mock_result = Mock()
+            mock_result.returncode = 0
+            mock_run.return_value = mock_result
+
+            result = self.git_service.branch_resolver._try_fetch_specific_branch(
+                self.repo_path, "feature-branch", "origin"
+            )
+
+            assert result is True
+            mock_run.assert_called_once_with(
+                ["git", "fetch", "origin", "feature-branch:feature-branch"],
+                cwd=self.repo_path,
+                timeout=30,
+                description="Fetch specific branch feature-branch from origin",
+            )
+
+    def test_try_fetch_specific_branch_fallback_to_simple_fetch(self):
+        """Test that _try_fetch_specific_branch falls back to simple fetch when first attempt fails."""
+        with patch("autowt.services.git.run_command_quiet_on_failure") as mock_run:
+            # First call fails, second succeeds
+            mock_result_fail = Mock()
+            mock_result_fail.returncode = 1
+            mock_result_success = Mock()
+            mock_result_success.returncode = 0
+            mock_run.side_effect = [Exception(), mock_result_success]
+
+            result = self.git_service.branch_resolver._try_fetch_specific_branch(
+                self.repo_path, "feature-branch", "origin"
+            )
+
+            assert result is True
+            # Should have been called twice due to fallback
+            assert mock_run.call_count == 2
+            mock_run.assert_any_call(
+                ["git", "fetch", "origin", "feature-branch"],
+                cwd=self.repo_path,
+                timeout=30,
+                description="Fetch branch feature-branch from origin",
+            )
+
+    def test_try_fetch_specific_branch_both_attempts_fail(self):
+        """Test that _try_fetch_specific_branch returns False when both fetch attempts fail."""
+        with patch("autowt.services.git.run_command_quiet_on_failure") as mock_run:
+            mock_run.side_effect = [Exception(), Exception()]
+
+            result = self.git_service.branch_resolver._try_fetch_specific_branch(
+                self.repo_path, "feature-branch", "origin"
+            )
+
+            assert result is False


### PR DESCRIPTION
Fixes #58

When creating worktrees for branches that don't exist locally, autowt now automatically checks if the branch exists on remote. If found, it fetches the branch and prompts the user to confirm creating a local worktree that tracks the remote branch.

Key improvements:
- Proactively fetches branches from remote before checking existence (addresses the core issue)
- Clear user prompt: "Branch 'name' exists on remote 'origin'. Create a local worktree tracking the remote branch?"
- Includes fallback fetch strategies for better reliability
- Can be bypassed with `--yes` flag for automated workflows
- Only applies when no explicit `--from` branch is specified

🤖 Generated with [Claude Code](https://claude.ai/code)