### PR TITLE
Remove 30-second timeout from git worktree remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Removed 30-second timeout from git worktree remove operations
+
 ## 0.4.4 - 2025-08-07
 
 ### Added

--- a/src/autowt/services/git.py
+++ b/src/autowt/services/git.py
@@ -394,7 +394,7 @@ class GitService:
 
         try:
             cmd = self.commands.worktree_remove(worktree_path, force)
-            result = run_command_visible(cmd, cwd=repo_path, timeout=30)
+            result = run_command_visible(cmd, cwd=repo_path)
 
             if result.returncode == 0:
                 logger.debug("Worktree removed successfully")


### PR DESCRIPTION
Removes the hardcoded 30-second timeout from git worktree remove operations, allowing them to run until completion.

🤖 Generated with [Claude Code](https://claude.ai/code)