### PR TITLE
Add VSCode and Cursor support as terminal options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Added
 
+- VSCode and Cursor support as terminal options - use `--terminal=vscode` or `--terminal=cursor` to open worktrees directly in editor windows
+- Window detection for VSCode and Cursor on macOS - switches to existing editor windows when possible instead of opening duplicates
+
 ### Changed
 
 ### Fixed

--- a/src/autowt/cli.py
+++ b/src/autowt/cli.py
@@ -304,7 +304,9 @@ class AutowtGroup(ClickAliasedGroup):
             params=[
                 click.Option(
                     ["--terminal"],
-                    type=click.Choice(["tab", "window", "inplace", "echo"]),
+                    type=click.Choice(
+                        ["tab", "window", "inplace", "echo", "vscode", "cursor"]
+                    ),
                     help="How to open the worktree terminal",
                 ),
                 click.Option(
@@ -571,7 +573,7 @@ def shellconfig(debug: bool, shell: str | None) -> None:
 @click.argument("branch", required=False)
 @click.option(
     "--terminal",
-    type=click.Choice(["tab", "window", "inplace", "echo"]),
+    type=click.Choice(["tab", "window", "inplace", "echo", "vscode", "cursor"]),
     help="How to open the worktree terminal",
 )
 @click.option(

--- a/src/autowt/models.py
+++ b/src/autowt/models.py
@@ -22,6 +22,8 @@ class TerminalMode(Enum):
     WINDOW = "window"
     INPLACE = "inplace"
     ECHO = "echo"
+    VSCODE = "vscode"
+    CURSOR = "cursor"
 
 
 class CleanupMode(Enum):


### PR DESCRIPTION
Adds new terminal modes `--terminal=vscode` and `--terminal=cursor` that open worktrees directly in editor windows using their CLI commands (`code -n` and `cursor -n`).

On macOS, includes smart window detection that switches to existing editor windows when possible instead of opening duplicates.

🤖 Generated with [Claude Code](https://claude.ai/code)