### PR TITLE
Handle more branch prefix edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Branch prefix is no longer applied when the exact branch name already exists locally or on remote
 - Integration tests were broken since 0.4.0 due to an overly broad mock
 
 ### Removed

--- a/src/autowt/commands/checkout.py
+++ b/src/autowt/commands/checkout.py
@@ -188,6 +188,12 @@ def checkout_branch(switch_cmd: SwitchCommand, services: Services) -> None:
     # Get current worktrees before applying prefix (we need to check if branches exist)
     git_worktrees = services.git.list_worktrees(repo_path)
 
+    def branch_exists(b: str) -> bool:
+        """Check if branch exists locally or on remote."""
+        return services.git.branch_resolver.branch_exists_locally(
+            repo_path, b
+        ) or services.git.branch_resolver.branch_exists_remotely(repo_path, b)
+
     # Apply branch prefix AFTER custom script resolution
     # This ensures dynamic branch names also get the prefix applied
     canonical_branch = get_canonical_branch_name(
@@ -197,6 +203,7 @@ def checkout_branch(switch_cmd: SwitchCommand, services: Services) -> None:
         repo_path,
         services,
         apply_to_new_branches=True,
+        branch_exists_fn=branch_exists,
     )
     if canonical_branch != switch_cmd.branch:
         switch_cmd = replace(switch_cmd, branch=canonical_branch)

--- a/tests/unit/services/test_git_service.py
+++ b/tests/unit/services/test_git_service.py
@@ -252,7 +252,7 @@ class TestBranchResolver:
         """Test that check_remote_branch_availability returns False when branch exists locally."""
         with patch.object(
             self.git_service.branch_resolver,
-            "_branch_exists_locally",
+            "branch_exists_locally",
             return_value=True,
         ):
             result = self.git_service.branch_resolver.check_remote_branch_availability(
@@ -265,7 +265,7 @@ class TestBranchResolver:
         with (
             patch.object(
                 self.git_service.branch_resolver,
-                "_branch_exists_locally",
+                "branch_exists_locally",
                 return_value=False,
             ),
             patch.object(
@@ -275,7 +275,7 @@ class TestBranchResolver:
             ),
             patch.object(
                 self.git_service.branch_resolver,
-                "_branch_exists_remotely",
+                "branch_exists_remotely",
                 return_value=True,
             ),
             patch.object(
@@ -295,7 +295,7 @@ class TestBranchResolver:
         with (
             patch.object(
                 self.git_service.branch_resolver,
-                "_branch_exists_locally",
+                "branch_exists_locally",
                 return_value=False,
             ),
             patch.object(
@@ -305,7 +305,7 @@ class TestBranchResolver:
             ),
             patch.object(
                 self.git_service.branch_resolver,
-                "_branch_exists_remotely",
+                "branch_exists_remotely",
                 side_effect=[
                     False,
                     True,
@@ -331,12 +331,12 @@ class TestBranchResolver:
         with (
             patch.object(
                 self.git_service.branch_resolver,
-                "_branch_exists_locally",
+                "branch_exists_locally",
                 return_value=False,
             ),
             patch.object(
                 self.git_service.branch_resolver,
-                "_branch_exists_remotely",
+                "branch_exists_remotely",
                 return_value=False,  # Not found remotely initially or after fetch
             ),
             patch.object(
@@ -355,12 +355,12 @@ class TestBranchResolver:
         with (
             patch.object(
                 self.git_service.branch_resolver,
-                "_branch_exists_locally",
+                "branch_exists_locally",
                 return_value=False,
             ),
             patch.object(
                 self.git_service.branch_resolver,
-                "_branch_exists_remotely",
+                "branch_exists_remotely",
                 return_value=False,  # Not found remotely before or after fetch
             ),
             patch.object(

--- a/tests/unit/test_branch_prefix.py
+++ b/tests/unit/test_branch_prefix.py
@@ -220,3 +220,67 @@ class TestGetCanonicalBranchName:
             mock_services,
         )
         assert result == "my-branch"
+
+    def test_branch_exists_fn_skips_prefix_when_branch_exists(self):
+        """Test that prefix is skipped when branch_exists_fn returns True."""
+        worktrees = []
+        mock_services = Mock()
+        mock_services.github.get_github_username.return_value = None
+
+        # Branch exists (locally or remotely) but has no worktree
+        branch_exists_fn = Mock(return_value=True)
+
+        result = get_canonical_branch_name(
+            "other/my-branch",
+            "feature/",
+            worktrees,
+            Path("/repo"),
+            mock_services,
+            apply_to_new_branches=True,
+            branch_exists_fn=branch_exists_fn,
+        )
+        assert result == "other/my-branch"
+        branch_exists_fn.assert_called_once_with("other/my-branch")
+
+    def test_branch_exists_fn_applies_prefix_when_branch_not_exists(self):
+        """Test that prefix is applied when branch_exists_fn returns False."""
+        worktrees = []
+        mock_services = Mock()
+        mock_services.github.get_github_username.return_value = None
+
+        # Branch does not exist
+        branch_exists_fn = Mock(return_value=False)
+
+        result = get_canonical_branch_name(
+            "my-branch",
+            "feature/",
+            worktrees,
+            Path("/repo"),
+            mock_services,
+            apply_to_new_branches=True,
+            branch_exists_fn=branch_exists_fn,
+        )
+        assert result == "feature/my-branch"
+        branch_exists_fn.assert_called_once_with("my-branch")
+
+    def test_worktree_check_takes_precedence_over_branch_exists_fn(self):
+        """Test that worktree check happens before branch_exists_fn."""
+        worktrees = [
+            WorktreeInfo(branch="my-branch", path=Path("/worktree")),
+        ]
+        mock_services = Mock()
+        mock_services.github.get_github_username.return_value = None
+
+        # branch_exists_fn should not be called if worktree exists
+        branch_exists_fn = Mock(return_value=False)
+
+        result = get_canonical_branch_name(
+            "my-branch",
+            "feature/",
+            worktrees,
+            Path("/repo"),
+            mock_services,
+            branch_exists_fn=branch_exists_fn,
+        )
+        assert result == "my-branch"
+        branch_exists_fn.assert_not_called()


### PR DESCRIPTION
When a branch prefix is configured (e.g., `a/`), running `awt go b/c` would incorrectly create or check out `a/b/c` even when `b/c` already exists as a local or remote branch.

The previous logic only checked if the branch existed as a worktree, but a branch can exist without having a worktree. This adds a callback to `get_canonical_branch_name()` that checks for local and remote branch existence before applying the prefix.