### PR TITLE
feat: add tab shell completion to switch to worktrees faster

### DIFF
--- a/src/autowt/cli.py
+++ b/src/autowt/cli.py
@@ -7,6 +7,7 @@ from importlib.metadata import version
 from pathlib import Path
 
 import click
+from click.shell_completion import CompletionItem
 from click_aliases import ClickAliasedGroup
 
 from autowt.cli_config import (
@@ -17,6 +18,7 @@ from autowt.cli_config import (
 from autowt.commands.checkout import checkout_branch
 from autowt.commands.cleanup import cleanup_worktrees
 from autowt.commands.config import configure_settings, show_config
+from autowt.commands.install_completion import install_completion as _install_completion
 from autowt.commands.ls import list_worktrees
 from autowt.config import get_config
 from autowt.global_config import options
@@ -28,6 +30,7 @@ from autowt.models import (
     TerminalMode,
 )
 from autowt.prompts import prompt_cleanup_mode_selection
+from autowt.services.completion import complete_worktree_branches
 from autowt.tui.switch import run_switch_tui
 from autowt.utils import (
     is_interactive_terminal,
@@ -165,6 +168,18 @@ class AutowtGroup(ClickAliasedGroup):
             pass
 
         return sorted(set(commands))
+
+    def shell_complete(self, ctx, incomplete):
+        """Extend Click's default subcommand completion with worktree branch names."""
+        completions = super().shell_complete(ctx, incomplete)
+
+        # Add existing worktree branches as completions.
+        # complete_worktree_branches returns (branch, help_text) pairs.
+        existing_names = {c.value for c in completions}
+        for branch, help_text in complete_worktree_branches(incomplete):
+            if branch not in existing_names:
+                completions.append(CompletionItem(branch, help=help_text))
+        return completions
 
     def _get_custom_script_names(self) -> set[str]:
         """Get names of all custom scripts from config."""
@@ -591,7 +606,15 @@ def config(debug: bool, show: bool) -> None:
     aliases=["sw", "checkout", "co", "goto", "go"],
     context_settings={"help_option_names": ["-h", "--help"]},
 )
-@click.argument("branch", required=False, metavar="BRANCH_OR_PATH")
+@click.argument(
+    "branch",
+    required=False,
+    metavar="BRANCH_OR_PATH",
+    shell_complete=lambda ctx, param, incomplete: [
+        CompletionItem(branch, help=help_text)
+        for branch, help_text in complete_worktree_branches(incomplete)
+    ],
+)
 @click.option(
     "--terminal",
     type=click.Choice(["tab", "window", "inplace", "echo", "vscode", "cursor"]),
@@ -693,6 +716,27 @@ def switch(
         dir=dir,
     )
     checkout_branch(switch_cmd, services)
+
+
+@main.command(
+    name="install-completion",
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+@click.option(
+    "--shell",
+    type=click.Choice(["bash", "zsh", "fish"]),
+    default=None,
+    help="Shell to install completion for (auto-detected if omitted)",
+)
+def install_completion_cmd(shell: str | None) -> None:
+    """Install tab completion for autowt in your shell.
+
+    Auto-detects your shell from the SHELL environment variable.
+    Supports bash, zsh, and fish.
+
+    Prints the line you need to add to your shell config file.
+    """
+    _install_completion(shell)
 
 
 if __name__ == "__main__":

--- a/src/autowt/cli.py
+++ b/src/autowt/cli.py
@@ -502,7 +502,15 @@ def ls(debug: bool) -> None:
     aliases=["cl", "clean", "prune", "rm", "remove", "del", "delete"],
     context_settings={"help_option_names": ["-h", "--help"]},
 )
-@click.argument("worktrees", nargs=-1, metavar="[WORKTREES...]")
+@click.argument(
+    "worktrees",
+    nargs=-1,
+    metavar="[WORKTREES...]",
+    shell_complete=lambda ctx, param, incomplete: [
+        CompletionItem(branch, help=help_text)
+        for branch, help_text in complete_worktree_branches(incomplete)
+    ],
+)
 @click.option(
     "--mode",
     type=click.Choice(["all", "remoteless", "merged", "interactive", "github"]),

--- a/src/autowt/commands/install_completion.py
+++ b/src/autowt/commands/install_completion.py
@@ -1,0 +1,76 @@
+"""Install shell completion for autowt."""
+
+import os
+import sys
+from pathlib import Path
+
+import click
+
+# Shell-specific setup instructions
+_BASH_SNIPPET = 'eval "$(_AUTOWT_COMPLETE=bash_source autowt)"'
+_ZSH_SNIPPET = 'eval "$(_AUTOWT_COMPLETE=zsh_source autowt)"'
+_FISH_SNIPPET = "_AUTOWT_COMPLETE=fish_source autowt | source"
+
+_FISH_COMPLETIONS_DIR = Path.home() / ".config" / "fish" / "completions"
+_FISH_COMPLETION_FILE = _FISH_COMPLETIONS_DIR / "autowt.fish"
+
+
+def _detect_shell() -> str | None:
+    """Detect the current shell from the SHELL environment variable."""
+    shell_path = os.environ.get("SHELL", "")
+    shell_name = Path(shell_path).name.lower()
+    if shell_name in ("bash", "zsh", "fish"):
+        return shell_name
+    return None
+
+
+def install_completion(shell: str | None) -> None:
+    """Print tab completion setup instructions for the given shell.
+
+    Args:
+        shell: Shell name ('bash', 'zsh', or 'fish'). Auto-detected if None.
+    """
+    detected = shell or _detect_shell()
+
+    if detected is None:
+        click.echo(
+            "Could not detect your shell. "
+            "Use --shell bash, --shell zsh, or --shell fish.",
+            err=True,
+        )
+        sys.exit(1)
+
+    if detected == "bash":
+        _install_bash()
+    elif detected == "zsh":
+        _install_zsh()
+    elif detected == "fish":
+        _install_fish()
+    else:
+        click.echo(
+            f"Shell '{detected}' is not supported. Supported shells: bash, zsh, fish.",
+            err=True,
+        )
+        sys.exit(1)
+
+
+def _install_bash() -> None:
+    click.echo("Add the following line to your ~/.bashrc:\n")
+    click.echo(f"    {_BASH_SNIPPET}\n")
+    click.echo("Then restart your shell or run:  source ~/.bashrc")
+
+
+def _install_zsh() -> None:
+    click.echo("Add the following line to your ~/.zshrc:\n")
+    click.echo(f"    {_ZSH_SNIPPET}\n")
+    click.echo("Then restart your shell or run:  source ~/.zshrc")
+
+
+def _install_fish() -> None:
+    click.echo(f"Add the following line to {_FISH_COMPLETION_FILE}:\n")
+    click.echo(f"    {_FISH_SNIPPET}\n")
+    click.echo("Or run:")
+    click.echo(
+        f"    mkdir -p ~/.config/fish/completions && "
+        f"echo '{_FISH_SNIPPET}' > {_FISH_COMPLETION_FILE}"
+    )

--- a/src/autowt/services/completion.py
+++ b/src/autowt/services/completion.py
@@ -1,0 +1,71 @@
+"""Shell completion helpers for autowt.
+
+Kept import-light intentionally: this module runs on every tab press inside a
+shell-spawned subprocess, so minimising Python import overhead matters.
+
+Only GitOutputParser is imported from the application — it has no heavy
+transitive dependencies (just WorktreeInfo from models).
+"""
+
+import subprocess
+from pathlib import Path
+
+from autowt.services.git import GitOutputParser
+
+
+def _find_repo_root() -> Path | None:
+    """Find the git repository root from the current directory."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return Path(result.stdout.strip())
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+    return None
+
+
+def _get_worktree_branches(repo_path: Path) -> list[str]:
+    """Return branch names of all existing worktrees.
+
+    Delegates porcelain parsing to GitOutputParser so the logic lives in one place.
+    Excludes detached-HEAD worktrees (they have no branch name).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=repo_path,
+        )
+        if result.returncode != 0:
+            return []
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return []
+
+    worktrees = GitOutputParser.parse_worktree_list(result.stdout)
+    return [wt.branch for wt in worktrees]
+
+
+def complete_worktree_branches(incomplete: str) -> list[tuple[str, str]]:
+    """Return (branch, help_text) pairs for existing worktrees matching *incomplete*.
+
+    Matching is case-insensitive substring search, so 'feat' matches
+    'foo-bar-feature-cool'. Returns an empty list on any error so completion
+    degrades gracefully.
+    """
+    repo_path = _find_repo_root()
+    if repo_path is None:
+        return []
+
+    branches = _get_worktree_branches(repo_path)
+    return [
+        (branch, "switch to this worktree")
+        for branch in branches
+        if incomplete.lower() in branch.lower()
+    ]

--- a/src/autowt/services/completion.py
+++ b/src/autowt/services/completion.py
@@ -3,14 +3,11 @@
 Kept import-light intentionally: this module runs on every tab press inside a
 shell-spawned subprocess, so minimising Python import overhead matters.
 
-Only GitOutputParser is imported from the application — it has no heavy
-transitive dependencies (just WorktreeInfo from models).
+No application modules are imported — only stdlib — so the import cost is minimal.
 """
 
 import subprocess
 from pathlib import Path
-
-from autowt.services.git import GitOutputParser
 
 
 def _find_repo_root() -> Path | None:
@@ -29,12 +26,33 @@ def _find_repo_root() -> Path | None:
     return None
 
 
-def _get_worktree_branches(repo_path: Path) -> list[str]:
-    """Return branch names of all existing worktrees.
+def _parse_worktree_branches(porcelain_output: str) -> list[str]:
+    """Extract branch names from 'git worktree list --porcelain' output.
 
-    Delegates porcelain parsing to GitOutputParser so the logic lives in one place.
-    Excludes detached-HEAD worktrees (they have no branch name).
+    Only returns branches (skips detached-HEAD worktrees).
+    This is an intentionally lightweight re-implementation that avoids importing
+    GitOutputParser (and its heavy transitive deps) on every tab press.
     """
+    branches: list[str] = []
+    current_branch: str | None = None
+
+    for line in porcelain_output.strip().split("\n"):
+        if not line:
+            if current_branch is not None:
+                branches.append(current_branch)
+            current_branch = None
+        elif line.startswith("branch refs/heads/"):
+            current_branch = line[18:]  # strip 'branch refs/heads/'
+
+    # Flush last entry (no trailing blank line)
+    if current_branch is not None:
+        branches.append(current_branch)
+
+    return branches
+
+
+def _get_worktree_branches(repo_path: Path) -> list[str]:
+    """Return branch names of all existing worktrees."""
     try:
         result = subprocess.run(
             ["git", "worktree", "list", "--porcelain"],
@@ -48,8 +66,7 @@ def _get_worktree_branches(repo_path: Path) -> list[str]:
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
         return []
 
-    worktrees = GitOutputParser.parse_worktree_list(result.stdout)
-    return [wt.branch for wt in worktrees]
+    return _parse_worktree_branches(result.stdout)
 
 
 def complete_worktree_branches(incomplete: str) -> list[tuple[str, str]]:

--- a/tests/unit/commands/test_commands.py
+++ b/tests/unit/commands/test_commands.py
@@ -3,7 +3,15 @@
 import os
 from unittest.mock import patch
 
+import pytest
+
 from autowt.commands import checkout, cleanup, ls
+from autowt.commands.install_completion import (
+    _BASH_SNIPPET,
+    _FISH_SNIPPET,
+    _ZSH_SNIPPET,
+    install_completion,
+)
 from autowt.models import (
     BranchStatus,
     CleanupCommand,
@@ -584,3 +592,60 @@ class TestCleanupCommand:
         # Verify it just exited with message
         captured = capsys.readouterr()
         assert "No worktrees selected for cleanup" in captured.out
+
+
+class TestInstallCompletionCommand:
+    """Tests for install_completion command function."""
+
+    def test_bash_prints_eval_snippet(self, capsys):
+        """Test that bash instructions include the correct eval line."""
+        install_completion("bash")
+        captured = capsys.readouterr()
+        assert _BASH_SNIPPET in captured.out
+        assert ".bashrc" in captured.out
+
+    def test_zsh_prints_eval_snippet(self, capsys):
+        """Test that zsh instructions include the correct eval line."""
+        install_completion("zsh")
+        captured = capsys.readouterr()
+        assert _ZSH_SNIPPET in captured.out
+        assert ".zshrc" in captured.out
+
+    def test_fish_prints_source_snippet(self, capsys):
+        """Test that fish instructions include the correct source line."""
+        install_completion("fish")
+        captured = capsys.readouterr()
+        assert _FISH_SNIPPET in captured.out
+        assert "autowt.fish" in captured.out
+
+    def test_unsupported_shell_exits(self):
+        """Test that an unsupported shell name causes a non-zero exit."""
+        with pytest.raises(SystemExit):
+            install_completion("tcsh")
+
+    def test_auto_detects_bash_from_env(self, capsys):
+        """Test that shell=None auto-detects bash from SHELL env var."""
+        with patch.dict(os.environ, {"SHELL": "/bin/bash"}):
+            install_completion(None)
+        captured = capsys.readouterr()
+        assert _BASH_SNIPPET in captured.out
+
+    def test_auto_detects_zsh_from_env(self, capsys):
+        """Test that shell=None auto-detects zsh from SHELL env var."""
+        with patch.dict(os.environ, {"SHELL": "/bin/zsh"}):
+            install_completion(None)
+        captured = capsys.readouterr()
+        assert _ZSH_SNIPPET in captured.out
+
+    def test_auto_detects_fish_from_env(self, capsys):
+        """Test that shell=None auto-detects fish from SHELL env var."""
+        with patch.dict(os.environ, {"SHELL": "/usr/bin/fish"}):
+            install_completion(None)
+        captured = capsys.readouterr()
+        assert _FISH_SNIPPET in captured.out
+
+    def test_undetectable_shell_exits(self):
+        """Test that shell=None with an unknown SHELL env exits non-zero."""
+        with patch.dict(os.environ, {"SHELL": "/bin/sh"}):
+            with pytest.raises(SystemExit):
+                install_completion(None)

--- a/tests/unit/services/test_completion_service.py
+++ b/tests/unit/services/test_completion_service.py
@@ -1,0 +1,197 @@
+"""Tests for the shell completion service."""
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from autowt.services.completion import (
+    _get_worktree_branches,
+    complete_worktree_branches,
+)
+
+# Realistic `git worktree list --porcelain` output used across multiple tests.
+_PORCELAIN_TWO_WORKTREES = """\
+worktree /home/user/myproject
+HEAD abc123def456
+branch refs/heads/main
+
+worktree /home/user/myproject-feature-foo
+HEAD 111222333444
+branch refs/heads/feature-foo
+
+"""
+
+_PORCELAIN_WITH_DETACHED = """\
+worktree /home/user/myproject
+HEAD abc123def456
+branch refs/heads/main
+
+worktree /home/user/myproject-detached
+HEAD deadbeef1234
+detached
+
+"""
+
+_PORCELAIN_MANY = """\
+worktree /home/user/myproject
+HEAD aaa
+branch refs/heads/main
+
+worktree /home/user/myproject-foo-bar
+HEAD bbb
+branch refs/heads/foo-bar
+
+worktree /home/user/myproject-foo-feature-cool
+HEAD ccc
+branch refs/heads/foo-feature-cool
+
+worktree /home/user/myproject-baz-foo-qux
+HEAD ddd
+branch refs/heads/baz-foo-qux
+
+"""
+
+
+def _make_subprocess_result(stdout: str = "", returncode: int = 0) -> Mock:
+    result = Mock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = ""
+    return result
+
+
+class TestGetWorktreeBranches:
+    """Tests for the _get_worktree_branches helper."""
+
+    def test_parses_single_worktree(self):
+        with patch("autowt.services.completion.subprocess.run") as mock_run:
+            mock_run.return_value = _make_subprocess_result(
+                stdout="""\
+worktree /home/user/myproject
+HEAD abc123
+branch refs/heads/main
+
+""",
+            )
+
+            result = _get_worktree_branches(Path("/home/user/myproject"))
+
+            assert result == ["main"]
+
+    def test_parses_multiple_worktrees(self):
+        with patch("autowt.services.completion.subprocess.run") as mock_run:
+            mock_run.return_value = _make_subprocess_result(
+                stdout=_PORCELAIN_TWO_WORKTREES
+            )
+
+            result = _get_worktree_branches(Path("/home/user/myproject"))
+
+            assert result == ["main", "feature-foo"]
+
+    def test_ignores_detached_head_worktrees(self):
+        with patch("autowt.services.completion.subprocess.run") as mock_run:
+            mock_run.return_value = _make_subprocess_result(
+                stdout=_PORCELAIN_WITH_DETACHED
+            )
+
+            result = _get_worktree_branches(Path("/home/user/myproject"))
+
+            assert result == ["main"]
+            assert "detached" not in result
+
+    def test_empty_output_returns_empty_list(self):
+        with patch("autowt.services.completion.subprocess.run") as mock_run:
+            mock_run.return_value = _make_subprocess_result(stdout="")
+
+            result = _get_worktree_branches(Path("/home/user/myproject"))
+
+            assert result == []
+
+    def test_git_error_returns_empty_list(self):
+        with patch("autowt.services.completion.subprocess.run") as mock_run:
+            mock_run.return_value = _make_subprocess_result(returncode=128)
+
+            result = _get_worktree_branches(Path("/home/user/myproject"))
+
+            assert result == []
+
+    def test_preserves_slashes_in_branch_names(self):
+        with patch("autowt.services.completion.subprocess.run") as mock_run:
+            mock_run.return_value = _make_subprocess_result(
+                stdout="""\
+worktree /home/user/myproject
+HEAD abc123
+branch refs/heads/feature/user-auth
+
+"""
+            )
+
+            result = _get_worktree_branches(Path("/home/user/myproject"))
+
+            assert result == ["feature/user-auth"]
+
+
+class TestCompleteWorktreeBranches:
+    """Tests for the public complete_worktree_branches function."""
+
+    def _patch_both(self, repo_path: str, porcelain_stdout: str, returncode: int = 0):
+        """Return context managers that mock both subprocess.run calls."""
+        root_result = _make_subprocess_result(stdout=repo_path + "\n", returncode=0)
+        worktree_result = _make_subprocess_result(
+            stdout=porcelain_stdout, returncode=returncode
+        )
+        return patch(
+            "autowt.services.completion.subprocess.run",
+            side_effect=[root_result, worktree_result],
+        )
+
+    def test_returns_all_worktrees_when_incomplete_is_empty(self):
+        with self._patch_both("/home/user/myproject", _PORCELAIN_MANY):
+            result = complete_worktree_branches("")
+
+            branches = [branch for branch, _ in result]
+            assert "main" in branches
+            assert "foo-bar" in branches
+            assert "foo-feature-cool" in branches
+            assert "baz-foo-qux" in branches
+            assert len(result) == 4
+
+    def test_prefix_match(self):
+        with self._patch_both("/home/user/myproject", _PORCELAIN_MANY):
+            result = complete_worktree_branches("foo")
+
+            branches = [branch for branch, _ in result]
+            assert "foo-bar" in branches
+            assert "foo-feature-cool" in branches
+            # baz-foo-qux also contains "foo" as substring — expected
+            assert "baz-foo-qux" in branches
+            # main does not contain "foo"
+            assert "main" not in branches
+
+    def test_substring_match(self):
+        """Core feature: 'feat' should match 'foo-feature-cool' even though
+        it does not start with 'feat'."""
+        with self._patch_both("/home/user/myproject", _PORCELAIN_MANY):
+            result = complete_worktree_branches("feat")
+
+            branches = [branch for branch, _ in result]
+            assert "foo-feature-cool" in branches
+
+    def test_case_insensitive_match(self):
+        with self._patch_both("/home/user/myproject", _PORCELAIN_MANY):
+            result = complete_worktree_branches("FEAT")
+
+            branches = [branch for branch, _ in result]
+            assert "foo-feature-cool" in branches
+
+    def test_no_match_returns_empty(self):
+        with self._patch_both("/home/user/myproject", _PORCELAIN_MANY):
+            result = complete_worktree_branches("zzz-no-match")
+
+            assert result == []
+
+    def test_exact_match(self):
+        with self._patch_both("/home/user/myproject", _PORCELAIN_TWO_WORKTREES):
+            result = complete_worktree_branches("main")
+
+            branches = [branch for branch, _ in result]
+            assert branches == ["main"]


### PR DESCRIPTION
I have quite a few worktrees created and it requires more steps than I think necessary to switch between them because I always forget the name of them.

So I want to try to reduce my workflow from instead typing `autowt list`, copying the worktree name, and then `autowt switch <paste>` with the branch name. It'd be great if I could just hit tab, and it does the filtering for me. This PR adds a new feature - shell autocomplete for worktree names to the `switch` and `remove` commands. 

# Changes 

- Using the Click framework and it's built-in support for implementing tab autocompletion, when you type `autowt switch foo<tab>` (or `autowt remove foo<tab>`), then autowt will now attempt to autocomplete the name of the worktree you're trying to type. When you hit tab, we get the list of available worktrees for the project and use that result for the tab completion values. 
- Added a new command `install-completion` meant to be a convenient way to teach you how to enable this tab completion feature. The command simply prints to you the command to put into your shell config file (example: `~/.zshrc`) by auto detecting the shell you're using. 
- Because you can type `autowt main` (without `switch` command) to change to a worktree, the `def shell_complete:` function was implemented which extends the built-in Click autocomplete feature so you can type `autowt sw<tab>` and it will autocomplete the "switch" command but also any worktrees that contain "sw" in it. 

# Reviewer notes

I don't have a lot of experience with building python CLIs or the Click framework. Open to suggestions on the implementation! 

## Performance 

Wanted to quickly mention that the performance does matter for this feature and its implementation. You'll see a commit in here where I improved the performance. I have a codebase where I have over a dozen worktrees, and I found this feature to be a little sluggish (~1 second to see completion results). But after the change I made, it is now fast enough to be happy with it (maybe 100ms delay to see results). 

# Testing 

Besides the automated tests, here are instructions for testing this feature. 

- run 'autowt install-completion' and it gives you instructions for your shell on how to install.
- after install, type 'autowt <tab>' to get a list of all commands that you can run. type 'autowt foo<tab>' (or 'autowt switch foo<tab>') to get a list of all existing worktrees that fuzzy search contain 'foo' in the name. 
- For remove command in particular, you can type `autowt remove main foo<tab>` and it will autocomplete "foo" while leaving "main" untouched. Since the remove command accepts a list, the auto complete works with lists.

--- 

Thanks for your consideration! 