### PR TITLE
Improve CLI help by showing built-in aliases and clarifying cleanup text

### DIFF
--- a/src/autowt/cli.py
+++ b/src/autowt/cli.py
@@ -528,7 +528,7 @@ def cleanup(
     force: bool,
     debug: bool,
 ) -> None:
-    """Clean up merged or remoteless worktrees. Aliases: cl, clean, prune, rm, remove, del, delete
+    """Remove specific worktrees, or clean up merged/remoteless ones. Aliases: cl, clean, prune, rm, remove, del, delete
 
     Can optionally specify worktrees (by branch name or path) to remove.
     If no worktrees are specified, uses mode-based selection.

--- a/src/autowt/cli.py
+++ b/src/autowt/cli.py
@@ -128,6 +128,32 @@ def _get_all_local_branches(repo_path: Path) -> list[str]:
 
 # Custom Group class that handles unknown commands as branch names and supports aliases
 class AutowtGroup(ClickAliasedGroup):
+    def _format_command_name(self, subcommand: str) -> str:
+        """Format a command name for help output, including aliases."""
+        aliases = self._commands.get(subcommand)
+        if aliases:
+            return f"{subcommand} ({', '.join(aliases)})"
+        return subcommand
+
+    def _collect_command_rows(
+        self,
+        ctx: click.Context,
+        formatter: click.HelpFormatter,
+        subcommands: list[str],
+    ) -> list[tuple[str, str]]:
+        """Collect help rows for a set of subcommands."""
+        commands: list[tuple[str, click.Command]] = []
+        for subcommand in subcommands:
+            cmd = self.get_command(ctx, subcommand)
+            if cmd is None or getattr(cmd, "hidden", False):
+                continue
+            commands.append((self._format_command_name(subcommand), cmd))
+
+        return [
+            (name, cmd.get_short_help_str(limit=formatter.width))
+            for name, cmd in commands
+        ]
+
     def get_command(self, ctx, cmd_name):
         # First, try to get the command normally (ls, cleanup, config, switch)
         rv = super().get_command(ctx, cmd_name)
@@ -182,35 +208,25 @@ class AutowtGroup(ClickAliasedGroup):
         custom_script_names = self._get_custom_script_names()
 
         # Collect all commands
-        commands = []
-        for subcommand in self.list_commands(ctx):
-            cmd = self.get_command(ctx, subcommand)
-            if cmd is None:
-                continue
-            help_text = cmd.get_short_help_str(limit=formatter.width)
-            commands.append((subcommand, help_text))
+        commands = self.list_commands(ctx)
 
         # Split into built-in and custom
         builtin_commands = [
-            (name, help_text)
-            for name, help_text in commands
-            if name not in custom_script_names
+            name for name in commands if name not in custom_script_names
         ]
-        custom_commands = [
-            (name, help_text)
-            for name, help_text in commands
-            if name in custom_script_names
-        ]
+        custom_commands = [name for name in commands if name in custom_script_names]
 
         # Write built-in commands section
-        if builtin_commands:
+        builtin_rows = self._collect_command_rows(ctx, formatter, builtin_commands)
+        if builtin_rows:
             with formatter.section("Commands"):
-                formatter.write_dl(builtin_commands)
+                formatter.write_dl(builtin_rows)
 
         # Write custom scripts section
-        if custom_commands:
+        custom_rows = self._collect_command_rows(ctx, formatter, custom_commands)
+        if custom_rows:
             with formatter.section("Custom Scripts"):
-                formatter.write_dl(custom_commands)
+                formatter.write_dl(custom_rows)
 
     def _create_custom_script_command(self, script_name: str, config):
         """Create a dynamic command for a custom script."""

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -211,6 +211,12 @@ class TestCLIRouting:
         assert result.exit_code == 0
         assert "Switch to or create a worktree" in result.output
 
+        # Cleanup help
+        result = runner.invoke(main, ["cleanup", "--help"])
+        assert result.exit_code == 0
+        assert "Remove specific worktrees" in result.output
+        assert "Can optionally specify worktrees" in result.output
+
     def test_main_help_shows_builtin_command_aliases(self):
         """Test that main --help includes built-in command aliases."""
         runner = CliRunner()
@@ -226,6 +232,7 @@ class TestCLIRouting:
             assert (
                 "cleanup (cl, clean, prune, rm, remove, del, delete)" in result.output
             )
+            assert "Remove specific worktrees" in result.output
             assert "config (configure, settings, cfg, conf)" in result.output
             assert "ls (list, ll)" in result.output
             assert "switch (sw, checkout, co, goto, go)" in result.output

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -211,6 +211,25 @@ class TestCLIRouting:
         assert result.exit_code == 0
         assert "Switch to or create a worktree" in result.output
 
+    def test_main_help_shows_builtin_command_aliases(self):
+        """Test that main --help includes built-in command aliases."""
+        runner = CliRunner()
+
+        with (
+            patch("autowt.cli.initialize_config"),
+            patch("autowt.cli.get_config") as mock_get_config,
+        ):
+            mock_get_config.return_value = create_mock_config()
+
+            result = runner.invoke(main, ["--help"])
+            assert result.exit_code == 0
+            assert (
+                "cleanup (cl, clean, prune, rm, remove, del, delete)" in result.output
+            )
+            assert "config (configure, settings, cfg, conf)" in result.output
+            assert "ls (list, ll)" in result.output
+            assert "switch (sw, checkout, co, goto, go)" in result.output
+
     def test_debug_flag_works(self):
         """Test that debug flag is handled correctly."""
         runner = CliRunner()


### PR DESCRIPTION
## Summary
- show built-in command aliases in the top-level `autowt --help` output
- refactor help row generation so built-in commands and custom scripts keep their separate sections while sharing the same formatting path
- clarify the `cleanup --help` summary so it covers both explicit worktree removal and mode-based cleanup
- add CLI tests for the top-level alias display and the updated cleanup help copy

## Testing
- `pytest tests/unit/cli/test_cli.py -q`