### PR TITLE
Add 'autowt hook <hook_name>' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Shell integration via `autowt shell-init <shell>` for bash, zsh, and fish. When enabled, worktree switches `cd` in your current shell instead of opening a new tab, so `source .env`, `conda activate`, and similar commands work natively. Includes a `--dry-run` flag to preview what would be eval'd.
 - Tab completion for `autowt switch` completes branch names that have existing worktrees. Activated automatically by `shell-init`.
+- `autowt hook <hook_name>` command to run a specific lifecycle hook standalone, so other worktree tools can shell out to autowt instead of duplicating hook configuration
 
 ### Changed
 

--- a/docs/clireference.md
+++ b/docs/clireference.md
@@ -133,6 +133,22 @@ autowt shell-init | source
 
 Commands that don't switch worktrees (`ls`, `cleanup`, `config`, etc.) continue to work normally with their output printed as-is.
 
+## `autowt hook <hook_name>`
+
+Runs a specific lifecycle hook using the configured global and project hooks. This is useful for integrating autowt's hook configuration with other worktree management tools, so they can shell out to autowt instead of duplicating hook configuration.
+
+`hook_name` must be one of: `pre_create`, `post_create`, `post_create_async`, `session_init`, `pre_cleanup`, `post_cleanup`, `pre_switch`, `post_switch`.
+
+The command auto-detects the repository root, worktree directory, and branch name from the current working directory. It exits with code 1 if any hook fails.
+
+```bash
+# Run session_init hooks from within a worktree
+cd ~/dev/my-project-worktrees/feature-branch
+autowt hook session_init
+
+# Run post_create hooks after another tool creates a worktree
+autowt hook post_create
+```
 ## Global options
 
 These options can be used with any `autowt` command.

--- a/docs/lifecyclehooks.md
+++ b/docs/lifecyclehooks.md
@@ -119,6 +119,21 @@ sequenceDiagram
     autowt-->>User: Cleanup complete
 ```
 
+## Running hooks standalone
+
+If you use another worktree tool but want to reuse autowt's hook configuration, you can run individual hooks with `autowt hook <hook_name>`:
+
+```bash
+# After your tool creates a worktree, cd into it and run:
+autowt hook post_create
+autowt hook session_init
+
+# Before your tool deletes a worktree:
+autowt hook pre_cleanup
+```
+
+The command auto-detects the repository root, worktree directory, and branch name from the current working directory. It runs the same global + project hook cascade as the built-in commands. See the [CLI reference](clireference.md#autowt-hook-hook_name) for details.
+
 ## Configuration
 
 Project-level and global hooks run independently and do not override each other.

--- a/docs/lifecyclehooks.md
+++ b/docs/lifecyclehooks.md
@@ -4,30 +4,29 @@
 
 ## Example: installing dependencies and copying secrets
 
-The most common hook is the **`session_init` script**, which runs in your new terminal session after creating a new worktree. This is perfect for setting up your shell environment, activating virtual environments, and running interactive setup tasks.
+The **`post_create` hook** runs as a subprocess after creating a new worktree but before switching to it. This is the right place for setup tasks like installing dependencies and copying files.
 
 ### Configuration
 
-Set the `scripts.session_init` key in your `.autowt.toml` file:
+Set the `scripts.post_create` key in your `.autowt.toml` file:
 
 ```toml
 # .autowt.toml
 [scripts]
-session_init = "npm install"
+post_create = "npm install"
 ```
 
 ### Copying `.env` files
 
-Worktrees start as clean checkouts, which means untracked files like `.env` are not automatically carried over. You can use an init script to copy these files from your main worktree.
+Worktrees start as clean checkouts, which means untracked files like `.env` are not automatically carried over. You can use a hook to copy these files from your main worktree.
 
 autowt provides environment variables that make this easier, including `AUTOWT_MAIN_REPO_DIR` which points to the main repository directory.
 
 ```toml
 # .autowt.toml
 [scripts]
-# Copy .env file from main worktree if it exists
-session_init = """
-npm install # kept from before
+post_create = """
+npm install
 if [ -f "$AUTOWT_MAIN_REPO_DIR/.env" ]; then
   cp "$AUTOWT_MAIN_REPO_DIR/.env" .;
 fi
@@ -36,7 +35,7 @@ fi
 
 ### Installing things in the background
 
-If your dependency installation step takes a long time, you might wish to do all this in `post_create_async` instead of `session_init`. That way, you can get an interactive terminal without waiting for everything to get set up.
+If your dependency installation step takes a long time, you might wish to use `post_create_async` instead. That way, you can get an interactive terminal without waiting for everything to finish.
 
 ```toml
 # .autowt.toml

--- a/src/autowt/cli.py
+++ b/src/autowt/cli.py
@@ -18,10 +18,12 @@ from autowt.cli_config import (
 from autowt.commands.checkout import checkout_branch
 from autowt.commands.cleanup import cleanup_worktrees
 from autowt.commands.config import configure_settings, show_config
+from autowt.commands.hook import run_hook_command
 from autowt.commands.ls import list_worktrees
 from autowt.commands.shell_init import detect_shell, get_shell_init_script
 from autowt.config import get_config
 from autowt.global_config import options
+from autowt.hooks import ALL_HOOK_TYPES
 from autowt.models import (
     CleanupCommand,
     CleanupMode,
@@ -658,6 +660,21 @@ def shell_init(shell: str | None, dry_run: bool) -> None:
                 "Please specify one: autowt shell-init bash|zsh|fish"
             )
     print(get_shell_init_script(shell, dry_run=dry_run))
+
+
+@main.command(context_settings={"help_option_names": ["-h", "--help"]})
+@click.argument("hook_name", type=click.Choice(ALL_HOOK_TYPES))
+@click.option("--debug", is_flag=True, help="Enable debug logging")
+def hook(hook_name: str, debug: bool) -> None:
+    """Run a specific lifecycle hook.
+
+    Runs the configured global and project hooks for the given hook type.
+    Useful for integrating autowt's hook configuration with other worktree tools.
+    """
+    setup_logging(debug)
+    services = create_services()
+    if not run_hook_command(hook_name, services):
+        raise SystemExit(1)
 
 
 @main.command(

--- a/src/autowt/commands/hook.py
+++ b/src/autowt/commands/hook.py
@@ -1,0 +1,69 @@
+"""Run a specific lifecycle hook."""
+
+import logging
+from pathlib import Path
+
+from autowt.console import print_error, print_info
+from autowt.hooks import extract_hook_scripts
+from autowt.models import Services
+
+logger = logging.getLogger(__name__)
+
+
+def _find_main_repo_dir(services: Services, repo_root: Path) -> Path:
+    """Find the primary (main) repository directory from any worktree."""
+    worktrees = services.git.list_worktrees(repo_root)
+    for worktree in worktrees:
+        if worktree.is_primary:
+            return worktree.path
+    return repo_root
+
+
+def run_hook_command(hook_name: str, services: Services) -> bool:
+    """Run a specific lifecycle hook using the global + project config cascade.
+
+    Args:
+        hook_name: The hook type to run (e.g. "session_init", "post_create")
+        services: Services container
+
+    Returns:
+        True if all hooks succeeded (or none were configured), False on failure.
+    """
+    repo_root = services.git.find_repo_root()
+    if not repo_root:
+        print_error("Not in a git repository")
+        return False
+
+    branch_name = services.git.get_current_branch(repo_root)
+    if not branch_name:
+        print_error("Could not determine current branch")
+        return False
+
+    worktree_dir = repo_root
+    main_repo_dir = _find_main_repo_dir(services, repo_root)
+
+    global_config = services.config_loader.load_config(project_dir=None)
+    project_config = services.state.load_config(project_dir=repo_root)
+
+    global_scripts, project_scripts = extract_hook_scripts(
+        global_config, project_config, hook_name
+    )
+    all_scripts = global_scripts + project_scripts
+
+    if not all_scripts:
+        print_info(f"No {hook_name} hooks configured")
+        return True
+
+    for script in all_scripts:
+        success = services.hooks.run_hook(
+            script,
+            hook_name,
+            worktree_dir,
+            main_repo_dir,
+            branch_name,
+        )
+        if not success:
+            print_error(f"{hook_name} hook failed")
+            return False
+
+    return True

--- a/src/autowt/hooks.py
+++ b/src/autowt/hooks.py
@@ -32,6 +32,18 @@ class HookType:
     POST_SWITCH = "post_switch"
 
 
+ALL_HOOK_TYPES = [
+    HookType.PRE_CREATE,
+    HookType.POST_CREATE,
+    HookType.POST_CREATE_ASYNC,
+    HookType.SESSION_INIT,
+    HookType.PRE_CLEANUP,
+    HookType.POST_CLEANUP,
+    HookType.PRE_SWITCH,
+    HookType.POST_SWITCH,
+]
+
+
 class HookRunner:
     """Executes lifecycle hooks with proper environment and arguments."""
 

--- a/tests/unit/commands/test_hook.py
+++ b/tests/unit/commands/test_hook.py
@@ -1,0 +1,113 @@
+"""Tests for the hook command."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from autowt.commands.hook import run_hook_command
+from autowt.hooks import HookType
+from autowt.models import WorktreeInfo
+
+
+class TestRunHookCommand:
+    def setup_method(self):
+        self.repo_root = Path("/repo")
+        self.main_repo_dir = Path("/repo-main")
+
+    def _configure_services(self, mock_services):
+        mock_services.git.repo_root = self.repo_root
+        mock_services.git.current_branch = "feature/test"
+        mock_services.git.worktrees = [
+            WorktreeInfo(branch="main", path=self.main_repo_dir, is_primary=True),
+            WorktreeInfo(branch="feature/test", path=self.repo_root, is_primary=False),
+        ]
+
+    def test_runs_global_and_project_scripts(self, mock_services):
+        self._configure_services(mock_services)
+        mock_services.hooks.run_hooks_success = True
+
+        with patch(
+            "autowt.commands.hook.extract_hook_scripts",
+            return_value=(["echo global"], ["echo project"]),
+        ):
+            result = run_hook_command(HookType.SESSION_INIT, mock_services)
+
+        assert result is True
+        assert len(mock_services.hooks.run_hook_calls) == 2
+        # Global script runs first
+        assert mock_services.hooks.run_hook_calls[0][0] == "echo global"
+        assert mock_services.hooks.run_hook_calls[0][1] == HookType.SESSION_INIT
+        # Project script runs second
+        assert mock_services.hooks.run_hook_calls[1][0] == "echo project"
+
+    def test_passes_correct_paths(self, mock_services):
+        self._configure_services(mock_services)
+        mock_services.hooks.run_hooks_success = True
+
+        with patch(
+            "autowt.commands.hook.extract_hook_scripts",
+            return_value=(["echo test"], []),
+        ):
+            run_hook_command(HookType.POST_CREATE, mock_services)
+
+        call = mock_services.hooks.run_hook_calls[0]
+        assert call[2] == self.repo_root  # worktree_dir
+        assert call[3] == self.main_repo_dir  # main_repo_dir
+        assert call[4] == "feature/test"  # branch_name
+
+    def test_no_scripts_configured(self, mock_services):
+        self._configure_services(mock_services)
+
+        with patch(
+            "autowt.commands.hook.extract_hook_scripts",
+            return_value=([], []),
+        ):
+            result = run_hook_command(HookType.SESSION_INIT, mock_services)
+
+        assert result is True
+        assert len(mock_services.hooks.run_hook_calls) == 0
+
+    def test_hook_failure_stops_and_returns_false(self, mock_services):
+        self._configure_services(mock_services)
+        mock_services.hooks.run_hooks_success = False
+
+        with patch(
+            "autowt.commands.hook.extract_hook_scripts",
+            return_value=(["echo first", "echo second"], []),
+        ):
+            result = run_hook_command(HookType.PRE_CLEANUP, mock_services)
+
+        assert result is False
+        # Stops after first failure
+        assert len(mock_services.hooks.run_hook_calls) == 1
+
+    def test_not_in_git_repo(self, mock_services):
+        mock_services.git.repo_root = None
+
+        result = run_hook_command(HookType.SESSION_INIT, mock_services)
+
+        assert result is False
+
+    def test_no_current_branch(self, mock_services):
+        mock_services.git.repo_root = self.repo_root
+        mock_services.git.current_branch = None
+
+        result = run_hook_command(HookType.SESSION_INIT, mock_services)
+
+        assert result is False
+
+    def test_falls_back_to_repo_root_when_no_primary(self, mock_services):
+        mock_services.git.repo_root = self.repo_root
+        mock_services.git.current_branch = "main"
+        mock_services.git.worktrees = []  # No worktrees found
+        mock_services.hooks.run_hooks_success = True
+
+        with patch(
+            "autowt.commands.hook.extract_hook_scripts",
+            return_value=(["echo test"], []),
+        ):
+            run_hook_command(HookType.SESSION_INIT, mock_services)
+
+        call = mock_services.hooks.run_hook_calls[0]
+        # Both worktree_dir and main_repo_dir should be repo_root
+        assert call[2] == self.repo_root
+        assert call[3] == self.repo_root


### PR DESCRIPTION
Lets other worktree tools shell out to autowt to run a specific lifecycle hook, reusing the same global + project config cascade without duplicating hook configuration.

The command auto-detects the repository root, worktree directory, and branch name from the current working directory. It runs each configured hook script in order (global then project) and exits 1 on first failure.