### PR TITLE
Fix shell-init zsh compatibility and env var warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ pip install autowt
 Optionally, set up shell integration so worktree switches `cd` in your current shell:
 
 ```bash
-# bash/zsh
-eval "$(autowt shell-init)"
+# bash/zsh (add to ~/.bashrc or ~/.zshrc)
+eval "$(autowt shell-init bash)"
 ```
 
 Then, make a new worktree for a new or existing branch in your current repo:

--- a/docs/clireference.md
+++ b/docs/clireference.md
@@ -118,11 +118,14 @@ Generates a shell function that wraps the `autowt` binary, enabling worktree swi
 When shell integration is active, commands like `autowt my-branch` change your working directory in your current shell instead of opening a new terminal tab. No terminal automation (AppleScript, tmux, etc.) is required.
 
 ```bash
-# Add to ~/.bashrc or ~/.zshrc:
-eval "$(autowt shell-init)"
+# Add to ~/.bashrc:
+eval "$(autowt shell-init bash)"
+
+# Add to ~/.zshrc:
+eval "$(autowt shell-init zsh)"
 
 # Add to ~/.config/fish/config.fish:
-autowt shell-init | source
+autowt shell-init fish | source
 ```
 
 <div class="autowt-clitable-wrapper"></div>

--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -79,7 +79,7 @@ If you prefer to stay in your existing terminal tab the whole time, you can set 
 
 ```bash
 # Add to your shell config once:
-eval "$(autowt shell-init)"  # auto-detects your shell
+eval "$(autowt shell-init bash)"  # or zsh/fish
 
 # Then just use autowt normally — it cd's in your current shell
 autowt hotfix/urgent-bug

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,8 +87,8 @@ pip install autowt
 Optionally, set up shell integration so worktree switches `cd` in your current shell:
 
 ```bash
-# bash/zsh
-eval "$(autowt shell-init)"
+# bash/zsh (add to ~/.bashrc or ~/.zshrc)
+eval "$(autowt shell-init bash)"
 ```
 
 Then, make a new worktree for a new or existing branch in your current repo:

--- a/docs/install.md
+++ b/docs/install.md
@@ -42,11 +42,14 @@ uvx autowt
 By default, autowt opens new terminal tabs when you switch worktrees. If you'd prefer worktree switches to `cd` in your current shell, add shell integration to your shell config:
 
 ```bash
-# bash (~/.bashrc) or zsh (~/.zshrc) — shell is auto-detected
-eval "$(autowt shell-init)"
+# bash (~/.bashrc)
+eval "$(autowt shell-init bash)"
+
+# zsh (~/.zshrc)
+eval "$(autowt shell-init zsh)"
 
 # fish (~/.config/fish/config.fish)
-autowt shell-init | source
+autowt shell-init fish | source
 ```
 
 See [Terminal Support](terminalsupport.md#shell-integration-alternative-to-terminal-automation) for details.

--- a/docs/terminalsupport.md
+++ b/docs/terminalsupport.md
@@ -22,12 +22,17 @@ Instead of opening new tabs or windows, you can have `autowt` change directories
 Add the appropriate line to your shell config:
 
 ```bash
-# ~/.bashrc or ~/.zshrc (shell is auto-detected from $SHELL)
-eval "$(autowt shell-init)"
+# ~/.bashrc
+eval "$(autowt shell-init bash)"
+
+# ~/.zshrc
+eval "$(autowt shell-init zsh)"
 
 # ~/.config/fish/config.fish
-autowt shell-init | source
+autowt shell-init fish | source
 ```
+
+The shell argument can be omitted if `$SHELL` matches your config file (i.e., your login shell is the same as the shell you're configuring). When in doubt, pass it explicitly.
 
 Once configured, running `autowt my-branch` will `cd` into the worktree in your current shell instead of opening a new tab or window. No terminal automation (AppleScript, tmux, etc.) is required, so this works in any terminal.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "autowt"
-version = "0.5.12.dev0"
+version = "0.6.0.dev1"
 description = "Customizable git worktree manager"
 readme = "README.md"
 license = "MIT"

--- a/src/autowt/cli.py
+++ b/src/autowt/cli.py
@@ -648,9 +648,9 @@ def shell_init(shell: str | None, dry_run: bool) -> None:
 
     \b
     Setup:
-      bash: eval "$(autowt shell-init)"       # add to ~/.bashrc
-      zsh:  eval "$(autowt shell-init)"       # add to ~/.zshrc
-      fish: autowt shell-init | source        # add to ~/.config/fish/config.fish
+      bash: eval "$(autowt shell-init bash)"   # add to ~/.bashrc
+      zsh:  eval "$(autowt shell-init zsh)"   # add to ~/.zshrc
+      fish: autowt shell-init fish | source   # add to ~/.config/fish/config.fish
     """
     if shell is None:
         shell = detect_shell()

--- a/src/autowt/commands/shell_init.py
+++ b/src/autowt/commands/shell_init.py
@@ -6,13 +6,13 @@ from pathlib import Path
 _BASH_ZSH_TEMPLATE = """\
 autowt() {{
     local tmpfile=$(mktemp)
-    trap 'rm -f "$tmpfile"' RETURN
     AUTOWT_SHELL_INTEGRATION_FILE="$tmpfile" command autowt "$@"
     local exit_code=$?
     if [ -s "$tmpfile" ]; then
         local eval_cmd=$(cat "$tmpfile")
         {eval_line}
     fi
+    rm -f "$tmpfile"
     return $exit_code
 }}
 alias awt=autowt

--- a/src/autowt/config.py
+++ b/src/autowt/config.py
@@ -376,8 +376,17 @@ class ConfigLoader:
             "CONFIRMATIONS_FORCE_OPERATIONS": ["confirmations", "force_operations"],
         }
 
+        # Env vars used internally by autowt but not for configuration
+        non_config_env_vars = {
+            "AUTOWT_SHELL_INTEGRATION_FILE",
+            "AUTOWT_TEST_FORCE_ECHO",
+            "AUTOWT_FORCE_UPGRADE_PROMPT",
+        }
+
         for key, value in os.environ.items():
             if not key.startswith("AUTOWT_"):
+                continue
+            if key in non_config_env_vars:
                 continue
 
             # Get the suffix after AUTOWT_

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "autowt"
-version = "0.5.12.dev0"
+version = "0.6.0.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "automate-terminal" },


### PR DESCRIPTION
Replace `trap ... RETURN` with explicit `rm -f` at function end. zsh doesn't support RETURN as a trap signal, causing 'undefined signal: RETURN' on every invocation.

Exclude AUTOWT_SHELL_INTEGRATION_FILE (and other internal env vars) from the config env var scanner, which was logging 'Unknown environment variable' warnings.

Update all docs to use explicit shell arguments in shell-init examples, since auto-detection uses $SHELL (login shell) which may differ from the shell being configured.