### PR TITLE
Add 'autowt -' to switch to the previous worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Shell integration via `autowt shell-init <shell>` for bash, zsh, and fish. When enabled, worktree switches `cd` in your current shell instead of opening a new tab, so `source .env`, `conda activate`, and similar commands work natively. Includes a `--dry-run` flag to preview what would be eval'd.
 - Tab completion for `autowt switch` completes branch names that have existing worktrees. Activated automatically by `shell-init`.
 - `autowt hook <hook_name>` command to run a specific lifecycle hook standalone, so other worktree tools can shell out to autowt instead of duplicating hook configuration
+- `autowt -` switches to the previous worktree, like `cd -`
 
 ### Changed
 

--- a/docs/clireference.md
+++ b/docs/clireference.md
@@ -11,6 +11,7 @@ Switch to a worktree, or create a new one. Accepts:
 - A branch name (e.g., `feature-branch`)
 - A branch name without prefix (if you've configured `branch_prefix`, you can omit it)
 - A path to an existing worktree directory
+- `-` to switch to the previous worktree (like `cd -`)
 
 Intelligently checks out existing branches from your default remote (i.e. `origin`), or offers to create a new one if none exists.
 

--- a/src/autowt/commands/checkout.py
+++ b/src/autowt/commands/checkout.py
@@ -177,7 +177,7 @@ def checkout_branch(switch_cmd: SwitchCommand, services: Services) -> None:
 
     # Handle '-' like 'cd -': switch to previous worktree
     if switch_cmd.branch == "-":
-        prev = services.state.get_previous_worktree_branch()
+        prev = services.state.get_previous_worktree_branch(repo_path)
         if prev is None:
             print_error("No previous worktree to switch to")
             return
@@ -200,7 +200,7 @@ def checkout_branch(switch_cmd: SwitchCommand, services: Services) -> None:
     # Record current worktree before switching (for 'autowt -' support)
     current_worktree = services.git.get_current_worktree(Path.cwd(), git_worktrees)
     if current_worktree:
-        services.state.set_previous_worktree_branch(current_worktree.branch)
+        services.state.set_previous_worktree_branch(repo_path, current_worktree.branch)
 
     def branch_exists(b: str) -> bool:
         """Check if branch exists locally or on remote."""

--- a/src/autowt/commands/checkout.py
+++ b/src/autowt/commands/checkout.py
@@ -175,6 +175,14 @@ def checkout_branch(switch_cmd: SwitchCommand, services: Services) -> None:
         print_error("Error: No branch name provided and dynamic resolution failed")
         return
 
+    # Handle '-' like 'cd -': switch to previous worktree
+    if switch_cmd.branch == "-":
+        prev = services.state.get_previous_worktree_branch()
+        if prev is None:
+            print_error("No previous worktree to switch to")
+            return
+        switch_cmd = replace(switch_cmd, branch=prev)
+
     # Resolve branch or path to a branch name
     try:
         resolved_branch = resolve_worktree_argument(switch_cmd.branch, services)
@@ -188,6 +196,11 @@ def checkout_branch(switch_cmd: SwitchCommand, services: Services) -> None:
 
     # Get current worktrees before applying prefix (we need to check if branches exist)
     git_worktrees = services.git.list_worktrees(repo_path)
+
+    # Record current worktree before switching (for 'autowt -' support)
+    current_worktree = services.git.get_current_worktree(Path.cwd(), git_worktrees)
+    if current_worktree:
+        services.state.set_previous_worktree_branch(current_worktree.branch)
 
     def branch_exists(b: str) -> bool:
         """Check if branch exists locally or on remote."""

--- a/src/autowt/services/state.py
+++ b/src/autowt/services/state.py
@@ -144,3 +144,14 @@ class StateService:
         state = self.load_app_state()
         state["experimental_terminal_warning_shown"] = True
         self.save_app_state(state)
+
+    def get_previous_worktree_branch(self) -> str | None:
+        """Get the branch of the worktree we last switched away from."""
+        state = self.load_app_state()
+        return state.get("previous_worktree_branch")
+
+    def set_previous_worktree_branch(self, branch: str) -> None:
+        """Record the branch of the worktree we're switching away from."""
+        state = self.load_app_state()
+        state["previous_worktree_branch"] = branch
+        self.save_app_state(state)

--- a/src/autowt/services/state.py
+++ b/src/autowt/services/state.py
@@ -145,13 +145,20 @@ class StateService:
         state["experimental_terminal_warning_shown"] = True
         self.save_app_state(state)
 
-    def get_previous_worktree_branch(self) -> str | None:
-        """Get the branch of the worktree we last switched away from."""
+    def get_previous_worktree_branch(self, repo_path: Path) -> str | None:
+        """Get the branch of the worktree we last switched away from in this repo."""
         state = self.load_app_state()
-        return state.get("previous_worktree_branch")
+        previous = state.get("previous_worktree_branch", {})
+        if isinstance(previous, dict):
+            return previous.get(str(repo_path))
+        return None
 
-    def set_previous_worktree_branch(self, branch: str) -> None:
-        """Record the branch of the worktree we're switching away from."""
+    def set_previous_worktree_branch(self, repo_path: Path, branch: str) -> None:
+        """Record the branch of the worktree we're switching away from in this repo."""
         state = self.load_app_state()
-        state["previous_worktree_branch"] = branch
+        previous = state.get("previous_worktree_branch", {})
+        if not isinstance(previous, dict):
+            previous = {}
+        previous[str(repo_path)] = branch
+        state["previous_worktree_branch"] = previous
         self.save_app_state(state)

--- a/tests/fixtures/service_builders.py
+++ b/tests/fixtures/service_builders.py
@@ -66,11 +66,18 @@ class MockStateService:
     def mark_experimental_terminal_warning_shown(self) -> None:
         self.app_state["experimental_terminal_warning_shown"] = True
 
-    def get_previous_worktree_branch(self) -> str | None:
-        return self.app_state.get("previous_worktree_branch")
+    def get_previous_worktree_branch(self, repo_path: Path) -> str | None:
+        previous = self.app_state.get("previous_worktree_branch", {})
+        if isinstance(previous, dict):
+            return previous.get(str(repo_path))
+        return None
 
-    def set_previous_worktree_branch(self, branch: str) -> None:
-        self.app_state["previous_worktree_branch"] = branch
+    def set_previous_worktree_branch(self, repo_path: Path, branch: str) -> None:
+        previous = self.app_state.get("previous_worktree_branch", {})
+        if not isinstance(previous, dict):
+            previous = {}
+        previous[str(repo_path)] = branch
+        self.app_state["previous_worktree_branch"] = previous
 
 
 class MockBranchResolver:

--- a/tests/fixtures/service_builders.py
+++ b/tests/fixtures/service_builders.py
@@ -66,6 +66,12 @@ class MockStateService:
     def mark_experimental_terminal_warning_shown(self) -> None:
         self.app_state["experimental_terminal_warning_shown"] = True
 
+    def get_previous_worktree_branch(self) -> str | None:
+        return self.app_state.get("previous_worktree_branch")
+
+    def set_previous_worktree_branch(self, branch: str) -> None:
+        self.app_state["previous_worktree_branch"] = branch
+
 
 class MockBranchResolver:
     """Mock branch resolver for testing."""

--- a/tests/unit/commands/test_checkout_dash.py
+++ b/tests/unit/commands/test_checkout_dash.py
@@ -22,7 +22,7 @@ class TestDashSwitchesToPrevious:
             WorktreeInfo(branch="branch-b", path=self.worktree_b),
         ]
         mock_services.terminal.switch_success = True
-        mock_services.state.app_state["previous_worktree_branch"] = "branch-b"
+        mock_services.state.set_previous_worktree_branch(self.repo_path, "branch-b")
 
         switch_cmd = SwitchCommand(branch="-", terminal_mode=TerminalMode.ECHO)
 
@@ -58,4 +58,7 @@ class TestDashSwitchesToPrevious:
         with patch("autowt.commands.checkout.Path.cwd", return_value=self.worktree_a):
             checkout_branch(switch_cmd, mock_services)
 
-        assert mock_services.state.get_previous_worktree_branch() == "branch-a"
+        assert (
+            mock_services.state.get_previous_worktree_branch(self.repo_path)
+            == "branch-a"
+        )

--- a/tests/unit/commands/test_checkout_dash.py
+++ b/tests/unit/commands/test_checkout_dash.py
@@ -1,0 +1,61 @@
+"""Tests for 'autowt -' (switch to previous worktree)."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from autowt.commands.checkout import checkout_branch
+from autowt.models import SwitchCommand, TerminalMode, WorktreeInfo
+
+
+class TestDashSwitchesToPrevious:
+    def setup_method(self):
+        self.repo_path = Path("/repo")
+        self.worktree_a = Path("/worktrees/branch-a")
+        self.worktree_b = Path("/worktrees/branch-b")
+
+    def test_dash_resolves_to_previous_branch(self, mock_services):
+        mock_services.git.repo_root = self.repo_path
+        mock_services.git.current_branch = "branch-a"
+        mock_services.git.worktrees = [
+            WorktreeInfo(branch="main", path=self.repo_path, is_primary=True),
+            WorktreeInfo(branch="branch-a", path=self.worktree_a),
+            WorktreeInfo(branch="branch-b", path=self.worktree_b),
+        ]
+        mock_services.terminal.switch_success = True
+        mock_services.state.app_state["previous_worktree_branch"] = "branch-b"
+
+        switch_cmd = SwitchCommand(branch="-", terminal_mode=TerminalMode.ECHO)
+
+        with patch("autowt.commands.checkout.Path.cwd", return_value=self.worktree_a):
+            checkout_branch(switch_cmd, mock_services)
+
+        assert mock_services.terminal.switch_calls
+        call = mock_services.terminal.switch_calls[0]
+        assert call[0] == self.worktree_b
+
+    def test_dash_with_no_previous_prints_error(self, mock_services, capsys):
+        mock_services.git.repo_root = self.repo_path
+        mock_services.git.current_branch = "branch-a"
+
+        switch_cmd = SwitchCommand(branch="-", terminal_mode=TerminalMode.ECHO)
+        checkout_branch(switch_cmd, mock_services)
+
+        # No switch should have happened
+        assert not mock_services.terminal.switch_calls
+
+    def test_switching_records_previous(self, mock_services):
+        mock_services.git.repo_root = self.repo_path
+        mock_services.git.current_branch = "branch-a"
+        mock_services.git.worktrees = [
+            WorktreeInfo(branch="main", path=self.repo_path, is_primary=True),
+            WorktreeInfo(branch="branch-a", path=self.worktree_a),
+            WorktreeInfo(branch="branch-b", path=self.worktree_b),
+        ]
+        mock_services.terminal.switch_success = True
+
+        switch_cmd = SwitchCommand(branch="branch-b", terminal_mode=TerminalMode.ECHO)
+
+        with patch("autowt.commands.checkout.Path.cwd", return_value=self.worktree_a):
+            checkout_branch(switch_cmd, mock_services)
+
+        assert mock_services.state.get_previous_worktree_branch() == "branch-a"


### PR DESCRIPTION
Like 'cd -', 'autowt -' switches back to the worktree you were last in. The previous worktree's branch is recorded in state.toml before every switch and resolved when '-' is passed as the branch argument.